### PR TITLE
list german area units with full names

### DIFF
--- a/src/resources/i18n/options.i18n.de-de.js
+++ b/src/resources/i18n/options.i18n.de-de.js
@@ -6,9 +6,9 @@ export default {
       miles: 'Meilen'
     },
     areUnits: {
-      sqKms: 'qk',
+      sqKms: 'Quadratkilometer',
       hectare: 'Hektar',
-      sqMeters: 'qm'
+      sqMeters: 'Quadratmeter'
     }
   }
 }


### PR DESCRIPTION
Other german units are given with their full name. This should be done for square kilometres and square metres as well.
If unit symbols are preferred, they, too, should be used consistently and the unit symbols for square kilometres should be `km²`, for square metres should be `m²`.
In this case, all other unit symbols should be changed as well.