### PR TITLE
Fix spelling grammar formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # ORS map client #
 
-This application implements a map client for the [openrouteservice API](https://openrouteservice.org/dev/#/api-docs/) as Single Page Application (SPA). It is a base application that can be used for multiple purposes, customized via configurarions and extended via plug-ins.
+This application implements a map client for the [openrouteservice API](https://openrouteservice.org/dev/#/api-docs/) as
+Single Page Application (SPA). It is a base application that can be used for multiple purposes,
+customized via configurations and extended via plug-ins.
 
-The base application is built using VueJS, Vuetify and a set of custom components, directives and services. The structure uses a feature-by-folder design, allowing view, code and translation elements to be contained in a folder.
+The base application is using VueJS, Vuetify and a set of custom components, directives and services.
+The structure uses a feature-by-folder design, allowing view, code and translation elements to be contained in a folder.
 
-This app uses single file components and others non-native javascript code that are transpiled to native javascript during the build process. That is way the app needs to be compiled before running it either in dev or production mode.
-The VueJS components allow a better code organization, weak and clear coupling between components and an easier code understanding.
+This app uses single file components and others non-native javascript code that are transpiled to native javascript
+during the build process.
+Therefore, the app needs to be compiled before running it either in dev or production mode.
+The VueJS components allow a better code organization, weak and clear coupling between components and an easier
+code understanding.
 
 ![ORS map client](docs/ors-map-client.png?raw=true "ORS map client")
 
@@ -17,7 +23,7 @@ The VueJS components allow a better code organization, weak and clear coupling b
 - [Feature-by-folder design](#feature-by-folder-design)
 - [Reserved methods and accessors](#reserved-methods-and-accessors)
 - [pages](#pages)
-- [Configuration, theming, customization and extension](#Configuration-theming-customization-and-extension)
+- [Configuration, theming, customization and extension](#configuration-theming-customization-and-extension)
 - [Add language](#add-language)
 - [Menu](#menu)
 - [Debug](#debug)
@@ -28,7 +34,9 @@ The VueJS components allow a better code organization, weak and clear coupling b
 
 Run the app locally in three steps: set the environment up, get the code and define a configuration file.
 
-1. To manage dependencies and pack the app it is necessary to have Node version 12. If you already have it, skip this step. If you don't, please install it by running:
+1. To manage dependencies and pack the app it is necessary to have Node version 12.
+If you already have it, skip this step.
+If you don't, please install it by running:
 
 ```sh
 curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
@@ -63,12 +71,12 @@ npm install
 4. Set the app-config.js values for:
 
 - `orsApiKey` - ORS API key to be used when ot running the app from localhost or ors valid domains
-- `bitlyApiKey` - the bitly key that will be used to shorten the share URL
-- `bitlyLogin` - the bitly login that will be used to shorten the share URL
+- `bitlyApiKey` - the Bitly key (used to shorten the share URL)
+- `bitlyLogin` - the Bitly login (used to shorten the share URL)
 
-5. The ORS menu is loaded/used by default. If you want to use a custom menu, have a look in the hooks-example.js
+5. The ORS menu is loaded/used by default. If you want to use a custom menu, have a look in the `hooks-example.js`.
 
-The map client filters, the theme and the hooks can be customized, if you need.
+The filters, theme and hooks of the map client can be customized if needed.
 
 At this point the app is ready to run in `dev` mode. Do it by executing the following command in the app root folder:
 
@@ -81,15 +89,15 @@ npm run dev
 
 App folder structure under `src`:
 
-- `assets` - where the images and icon sare stored
+- `assets` - images and icons storage
 - `common` - available mixins, http client, main menu, Vue with Vuetify and theme
 - `directives` - custom directives
 - `filters` - custom filters
 - `fragments` - all app fragments used by pages
 - `i18n` - internationalization resources
 - `models` - models used to deal transport ors response data and deals with app state and transitions
-- `pages` - app pages. currently only the `maps` page is available
-- `resoures` - where support files like the loader lib, definitions and options used to process requests, responses are placed
+- `pages` - app pages (currently only the `maps` page is available)
+- `resoures` - support files like the loader lib, definitions and options used to process requests and responses
 - `router` - router component based on vue-router
 - `shared-services` - shared services that can be used by various components
 - `store` - app store definitions
@@ -97,33 +105,51 @@ App folder structure under `src`:
 
 ### App flow overview ###
 
-This is a Single Page Application (SPA). This means that the client app is loaded on the browser and defines which components and pages are processed based on the browser URL. The app watches every change in the browser URL and updates its state based on that. These URL changes don't trigger a request to the back-end directly, but the components loaded/updated will decide which RESTfull requests must be run to load the required data. In other words, it means that the front-end (this app) is decoupled from the back-ends (ORS API and ORS website)
+This is a Single Page Application (SPA). This means that the client app is loaded in the browser and defines which
+components and pages are processed based on the browser URL.
+The app watches every change in the browser URL and updates its state based on that.
+These URL changes don't trigger a request to the back-end directly, but the components loaded/updated will decide which
+requests must be run to load the required data.
+Meaning, that the front-end (this app) is decoupled from the back-ends (ORS API and ORS website)
 
 The app load cycle follows these steps:
 
 1. Execute the `main.js` file and add global extensions, mixins components and external libs.
 2. The registered hooks are loaded and the `appLoaded` hook is run.
-3. The `main.js` also includes the main router script, the main vuex store and the main i18n file, that will internally, each one, load all the additional `.router.js` files, `.store.js` files and `.i18n.js` files.
-4. `main.js` file will create a VueJS app instance and load the `App.vue`. At this point `AppHooks` is set up and attached to the main VueJS instance and the hook `appLoaded` is run.
-5. `App.vue` includes all basic navigation components, like menu, sidebar, footer and etc.
-6. As soon as all the routes are loaded, including the ones in the `pages` sub folder, the page with the `/` route will also be rendered in the `<router-view></router-view>` in `App.vue` component.
+3. The `main.js` also includes the main files for the router, vuex-store and i18n-translations, which will internally
+load all `.router.js` ,`.store.js` and `.i18n.js` files from sub-folders.
+4. `main.js` file will create a VueJS app instance and load the `App.vue`.
+At this point `AppHooks` is set up and attached to the main VueJS instance and the hook `appLoaded` is run.
+5. `App.vue` includes all basic navigation components, like menu, sidebar, footer etc.
+6. After loading all routes (including the ones in the `pages` sub folder) the page with the `/` route will
+ also be rendered in the `<router-view></router-view>` in `App.vue` component.
 
 Data flow, state and requests to services, in a simplified view, happens as follows:
 
 - The app is loaded
-  1. the API data are fetched from ORS website service and if `appConfig.appMenu.useORSMenu` is **true**, the menu items are loaded in `src/main.js` using `src/app-loader.js`.
+  1. the API data are fetched from ORS website service and if `appConfig.appMenu.useORSMenu` is **true**, the menu items
+   are loaded in `src/main.js` using `src/app-loader.js`.
   2. the app `mode` is defined based on the matching URL in the `maps.route.js`
-  3. the `maps` page, uses the app mode utility to define the app state using the current `mode`. This utility will also populate the values of the `ors-map-filters` based on the URL and build the `AppRouteData` (in src/models/app-route-data.js).
+  3. the `maps` page, uses the app mode utility to define the app state using the current `mode`.
+   This utility will also populate the values of the `ors-map-filters` based on the URL and build the `AppRouteData`
+   (in src/models/app-route-data.js).
   4. based on the app mode/state certain components are activated/displayed
-  5. Every component, once activated, may use the data in `src/config/ors-map-filters` to render its elements and  may run requests to the ORS api using the `src/support/ors-api-runner`. Once the request succeed, the response data will be used to fill the `MapViewData` object.
+  5. Every component, once activated, may use the data in `src/config/ors-map-filters` to render its elements and may
+   run requests to the ORS api using the `src/support/ors-api-runner`.
+   Once the request succeed, the response data will be used to fill the `MapViewData` object.
   6. Once an input is changed the app goes to a new URL and this makes the flow restart at the step 2.
-  7. If a component changes the `MapViewData` model, it emits an event to the `maps` page, that passes the current `MapViewData` object to the `MapView` component.
-  8. Interactions via `MapView` may result in events sent back to `maps` page, that may notify other child components, that in their turn may change the URL and trigger the step 2 again.
-  9. Several app hooks are called during the app flow and and it is possible to listen to these hooks and run custom code to modify some of the app behavior. The available hooks are listed in `src/config/hook-example.js` and must be coded in `src/config/hooks.js`.
+  7. If a component changes the `MapViewData` model, it emits an event to the `maps` page, that passes the current
+   `MapViewData` object to the `MapView` component.
+  8. Interactions via `MapView` may result in events sent back to `maps` page, that may notify other child components,
+   that in their turn may change the URL and trigger the step 2 again.
+  9. Several app hooks are called during the app flow, and it is possible to listen to these hooks and run custom code
+   to modify some app behavior.
+    The available hooks are listed in `src/config/hook-example.js` and must be coded in `src/config/hooks.js`.
 
 ### Feature-by-folder design ###
 
-This app uses feature by folder components and predefined folders where the business code should be placed in. Example of this design usage:
+This app uses feature by folder components and predefined folders where the business code should be placed in.
+Example of this design usage:
 
 Page:
 
@@ -153,7 +179,8 @@ The app will automatically load:
 
 ### Reserved methods and accessors ###
 
-All the VueJS components created (including the fragments) will have, by default, the following methods/accessors define din the main vue instance app:
+All the VueJS components created (including the fragments) will have, by default, the following methods/accessors
+ defined in the main vue instance app:
 
 - `showMessage (msg, theme, options)` - shows a message using the toaster with specified theme and options
 
@@ -165,11 +192,12 @@ All the VueJS components created (including the fragments) will have, by default
 
 - `showSuccess (msg, options)` - shows a success message using the toaster with the specified options
 
-- `confirmDialog (title, text, options)` - shows a confirm dialog with the specified title, text and options and returns a promise. If the user clicks `yes`, the promise will be resolved, if s/he clicks on `no`, the promise will be rejected.
+- `confirmDialog (title, text, options)` - shows a confirm-dialog with the specified title, text and options and returns
+a promise. If the user clicks `yes`, the promise will be resolved, if s/he clicks on `no`, the promise will be rejected.
 
-- `eventBus` - accessor to global event bus object, that allows to broadcast and get events in all components
+- `eventBus` - accessor to global event bus object, that allows broadcasting and getting events in all components
 
-- `$store` - accessor to app store that used vuex
+- `$store` - accessor to app vuex-store
 
 ### Pages ###
 
@@ -177,9 +205,14 @@ All the VueJS components created (including the fragments) will have, by default
 
 ### Configuration, theming, customization and extension ###
 
-The map client app can be configured, customized and extended. Several aspects can be defined/changed in order to disable features, customize visual identity and change/extend its features/behaviors. It is also possible to add plug-ins to the app and subscribe to hooks, listen and emit evens that will make the app respond to specific needs. The items of the menu can also be customized via hooks.
+The map client app can be configured, customized and extended. Several aspects can be defined/changed in order to
+disable features, customize visual identity and change/extend its features/behaviors.
+It is also possible to add custom plug-ins to the app and subscribe to hooks, listen and emit events.
+The items of the menu can also be customized via hooks.
 
-It is possible to define your custom settings and plug-ins and keep getting updates from the ORS repository because the `src/plugins` and `src/config` folders are not vesioned. To keep the original ors-map-client as a secondary repository, do the following:
+It is possible to define your custom settings and plug-ins and keep getting updates from the ORS repository because
+the `src/plugins` and `src/config` folders are not versioned.
+To keep the original ors-map-client as a secondary repository, do the following:
 
 ```sh
 # Rename the original remote
@@ -192,7 +225,9 @@ git remote add origin <git-repo-url>
 git branch --set-upstream-to=origin/master
 ```
 
-After doing this we recommend you to remove from `.gitignore` the lines that tell git to ignore the folders `/src/config`, `src/plugins` and eventually `/static`. Then  run the initial push to the just defined new origin repository, with the following command:
+After doing this we recommend you to remove from `.gitignore` the lines that tell git to ignore the folders
+`/src/config`, `src/plugins` and eventually `/static`.
+Then, run the initial push to the just defined new origin repository, with the following command:
 
 ```sh
 git push -u origin master
@@ -202,66 +237,95 @@ The ways to change/extend the app are:
 
 1. Define custom settings (see files in `src/config`) that will change the standard way that the app works.
 1. Add hook listeners in `src/config/hooks.js` and run custom code inside those hooks
-1. Create a plug-in that will have its methods linked to hooks called during the app flow (see `src/plugins/example-plugin/`)
+1. Create a plug-in that has its methods linked to hooks called during the app flow
+(see `src/plugins/example-plugin/`)
 
 #### Configuration ####
 
 It is possible to configure/disable some app features and behaviors by changing the values
-of the `src/config/app-config.js`. It is also possible to change the app theme/colors by changing the values of `src/config/theme.js`. The app logo can also be changed in the `src/config/app-config` file. The available filters/options to be used in the services are defined in the `src/config/ors-map-filters.js`. They can be adjusted according the needs. Other files can be used to adjust app configurations are the `layer-zoom-mapping.js`, `settings-options.js` and the `default-map-settings.js`.
+of the `src/config/app-config.js`. It is also possible to change the app theme/colors by changing the values of
+`src/config/theme.js`.
+The app logo can also be changed in the `src/config/app-config` file.
+The available filters/options to be used in the services are defined in the `src/config/ors-map-filters.js`.
+They can be adjusted according the needs. Other files can be used to adjust app configurations are the
+`layer-zoom-mapping.js`, `settings-options.js` and the `default-map-settings.js`.
 
 #### Plug-ins ####
 
 It is possible to add plug-ins to the application in order to change its behavior or extend it.
-Please check the `src/plugins` folder, the [plug-ins readme](src/plugins/readme.md) and the [plugin example](src/plugins/plugin-example/plugin-example.js) for more details.
+Please check the `src/plugins` folder, the [plug-ins readme](src/plugins/readme.md) and the
+[plugin example](src/plugins/plugin-example/plugin-example.js) for more details.
 
 ### Add language ###
 
 #### - Generate a translation file ####
 
-If you just want to translate the application strings for a certain language, but you don't have the skills to `"code"` it into the app, just download the [en-translation-source-merged.json](/docs/en-translation-source-merged.json), translate it, and contact us.
+If you just want to translate the application strings for a certain language, but you don't have the skills to `"code"`
+it into the app, just download the [en-translation-source-merged.json](/docs/en-translation-source-merged.json),
+translate it, and contact us.
 
 **Check the file [src/i18n/i18n-builder.js](src/i18n/i18n-builder.js) to see how to generate merged translation sources*
 
 #### - Add a language to the app ####
 
-The app uses a feature-by-folder design, so each component might have its own translation strings. That is why there is no single translation file. If you want to add a translation and `"implement"` it into the app, follow the steps below.
+The app uses a feature-by-folder design, so each component might have its own translation strings.
+That is why there is no single translation file. If you want to add a translation and `"implement"` it into the app,
+follow the steps below.
 
-- Create a copy of the /src/i18n/translations/`en-us` folder giving it the identification of the target language. For example: if you are adding the French from France, then the folder should be called `fr-fr`.
+- Create a copy of the /src/i18n/translations/`en-us` folder giving it the identification of the target language.
+For example: if you are adding the French from France, then the folder should be called `fr-fr`.
 
-- Edit the builder.js file inside the just created folder in order to replace the language pattern to the one you are creating. For example, where is /\.i18n\.`en-us\`.js$, put /\.i18n\.`fr-fr`\.js$
+- Edit the builder.js file inside the just created folder in order to replace the language pattern to the one you are
+creating.
+For example, similar to `/\.i18n\.en-us\.js$` add `/\.i18n\.fr-fr\.js$`.
 
 - Translate the language strings for each key in the `global.js` file
 
-- Search for each file inside the `/src` folder that ends with `i18n.en-en.js` and create a copy of it and each one so that each new created file now ends with `i18n.fr-fr.js`
+- Search for each file inside the `/src` folder that ends with `i18n.en-en.js` and create a copy of it and each one so
+that each new created file now ends with `i18n.fr-fr.js`
 
 - Translate the language strings for each key in all the files created in the previous step.
 
-- Edit the /src/config/`settings-options.js`and add the new locale object to the `appLocales` array. For this example, you would add { text: 'Français FR', value: 'fr-fr' }
+- Edit `/src/config/settings-options.js` and add the new locale object to the `appLocales` array (e.g.
+ `{ text: 'Français FR', value: 'fr-fr' }`).
 
 - Open the src/i18n/`i18n-builder.js` file and apply the following changes:
-  - Import the object from the new language builder that you just created. For this example it would be `import frFRTranslations from './translations/fr-fr/builder`'
+  - Import the object from the new language builder that you just created
+  (e.g. `import frFRTranslations from './translations/fr-fr/builder'`)
 
-  - Inside the `build` method, add the new language placeholder object to the messages object. For this example you would add `, 'fr-fr': {}`
-  
-  - Still inside the `build` method, add the result of the new language building to the previously created message object. In this example you would add: `i18n.messages['fr-fr'] = frFRTranslations.build()`
-  
+  - Inside the `build` method, add:
+
+    - the new language placeholder object to the messages object (e.g. `, 'fr-fr': {}`).
+
+    - the result of the new language building to the previously created message object
+     (e.g. `i18n.messages['fr-fr'] = frFRTranslations.build()`.
+
   - Save all the files changed and rebuild the application.
 
 ### Menu ###
 
-The menu displayed in the header and in the sidebar (low resolution and mobile devices) is loaded from the ORS website back-end and adjusted to be shown according the resolution.
+The menu displayed in the header and in the sidebar (low resolution and mobile devices) is loaded from the ORS website
+back-end and adjusted to be shown according the resolution.
 
-The menu items are fetched on the app load (`src/app-loader.js`). It dispatches the store `fetchMainMenu` and the menu is retrieved by `@/common/main-menu.js` that internally uses `@/support/menu-manager.js` and `@/support/model-service.js`.
-Once the items from the back-end are loaded, `MenuManager` is used to add/remove custom items and define sidebar item icons. The items displayed on the menu can be changed by running custom code on the `loadMenuItems`  and/or the `modifyMenu` hooks. Check the `/src/config-example/hooks-example.js` to see more details.
+The menu items are fetched on the app load (`src/app-loader.js`).
+It dispatches the store `fetchMainMenu` and `@/common/main-menu.js` retrieves the menu that uses
+`@/support/menu-manager.js` and `@/support/model-service.js`.
+Once the items from the back-end are loaded, `MenuManager` adds or removes custom items and defines icons for sidebar
+items.
+The items displayed on the menu can be changed by running custom code on the `loadMenuItems`  and/or the
+`modifyMenu` hooks. Check the `/src/config-example/hooks-example.js` to see more details.
 
 ### Debug ###
 
 If you are using [WebStorm](https://www.jetbrains.com/webstorm/download) you should set the
-_webpack config_ (settings -> Languages & Frameworks -> JavaScript -> Webpack) to `{path to ors-map-client}/build/webpack.base.conf.js` so the file paths are resolved correctly.
+_webpack config_ (settings -> Languages & Frameworks -> JavaScript -> Webpack) to
+`{path to ors-map-client}/build/webpack.base.conf.js` to resolve file paths correctly.
 
 To debug the application you must run it in [`dev` mode](#set-up-and-run-locally).
-For better debugging in your browser install the [VueJS devtools](https://github.com/vuejs/vue-devtools#installation) extension.
-After doing that, open the application in the browser and press F12 and select the tab `Console`, `Vue` or `Sources` (and then expand e.g.: `webpack://src`).
+For better debugging in your browser install the [VueJS devtools](https://github.com/vuejs/vue-devtools#installation)
+extension.
+After doing that, open the application in the browser and press F12 and select the tab `Console`, `Vue` or `Sources`
+(and then expand e.g.: `webpack://src`).
 
 ### Build and deploy ###
 
@@ -272,29 +336,52 @@ cd <project-root-folder>/
 npm run build
 ```
 
-*Important:* to run the built application you must to set up a web server and put this repository (after the build) there. The `index.html` at the root of this repository is expected to load the app.
+*Important:* to run the built application you have to set up a web server and put this repository (after the build)
+there.
+The `index.html` at the root of this repository will load the app.
 
-For a detailed explanation on how webpack works, check out the [guide](http://vuejs-templates.github.io/webpack/) and [docs for vue-loader](http://vuejs.github.io/vue-loader).
+For a detailed explanation on how webpack works, check out the [guide](http://vuejs-templates.github.io/webpack/) and
+[docs for vue-loader](http://vuejs.github.io/vue-loader).
 
 ### Contribute ###
 
 #### Branch policy ####
 
-The `develop` branch is used as the working branch. Anything new goes to develop and then it is tested, committed and finally merged into `master`. So, develop has always the latest version (latest but not necessarily the production one) while `master` has the production version. Considering this, any merge request must be tone targeting `develop`. If you want to work on a feature we recommend you to create a feature branch then when it is finished send a merge request to `develop`.
+The `develop` branch is used as the working branch. Anything new goes to develop and then it is tested, committed and
+finally merged into `master`.
+So, develop has always the latest version (latest but not necessarily the production one) while `master` has the
+production version.
+Considering this, any merge request must be tone targeting `develop`.
+If you want to work on a feature we recommend you to create a feature branch then when it is finished send a merge
+request to `develop`.
 
-Like almost every team, we have limited workforce and we have to define priorities.
+Like almost every team, we have limited workforce, and we have to define priorities.
 
 `Bugs`:
-If you have identified any bug and think that you can help fixing it, please create an issue first, instead of directly submitting a push request. So the people involved will have the opportunity to discuss it.
+If you have identified any bug and think that you can help to fix it, please create an issue first, instead of directly
+submitting a push request.
+So the people involved will have the opportunity to discuss it.
 
 `New festures`:
-If you want to contribute by adding a new feature or improve an existing one, please also create an issue. We do want contributions and the community effort is very important to us, but features may add complexity and future maintenance effort. Because of this, we have also to analyze the trade off of such contributions. We just have to decide about them together before the hands on. This approach is intended to create cohesion and keep the project sustainable.
+If you want to contribute by adding a new feature or improve an existing one, please also create an issue.
+We do want contributions, and the community effort is very important to us, but features may add complexity and future
+maintenance effort.
+Because of this, we have also to analyze the trade off of such contributions.
+We just have to decide about them together before the hands on.
+This approach is intended to create cohesion and keep the project sustainable.
 
 #### Current needs ####
 
-As you may notice, this project is an on going project and thus, there is a lot of room for improvement. We already have in mind some of these possible improvements and some of them are listed below:
+As you may notice, this project is an ongoing project and thus, there is a lot of room for improvement.
+Some are listed below (ordered by priority):
 
-- `Tests` (unit, e2e) - we need it, but we were not able to implement it yet. It is one of the priorities of our list. So, if you can contribute with it, please let us know.
-- `Rendering performance` - we are continuously looking for performance improvement. If you think you can suggest a better way to deal with the rendering phase in a way that it improves the speed, please tell us. We are relying on [Vue2leaflet](https://github.com/vue-leaflet/Vue2Leaflet) for this.
+- `Tests` (unit, e2e) - we need it, but we were not able to implement it yet.
+ It is one of the priorities of our list.
+ So, if you can contribute with it, please let us know.
+- `Rendering performance` - we are continuously looking for performance improvement.
+ If you think you can suggest a better way to deal with the rendering phase in a way that it improves the speed,
+ please tell us.
+ We are relying on [Vue2leaflet](https://github.com/vue-leaflet/Vue2Leaflet) for this.
 - `Accessibility` of the app for people with special needs
-- `User test` to check that the app works in multiple browsers, resolutions and devices (versions of Mac, Windows, Linux, Android and Iphone) and their multiple possible browsers
+- `User test` to check that the app works in multiple browsers, resolutions and devices (versions of Mac, Windows,
+ Linux, Android and Iphone) and their multiple possible browsers

--- a/changelog.md
+++ b/changelog.md
@@ -36,6 +36,11 @@ RELEASING:
 8. Add version to docker-compose.yml (grunt version always adds 1 on top the current version ...)
  -->
 
+## [Unreleased]
+
+### Fixed
+- Spelling, formatting and grammar issues in the README.md, documentation, changelog and comments
+
 ## [v1.0.12] - 2021-04-28 ##
 
 ### Added ###

--- a/changelog.md
+++ b/changelog.md
@@ -39,100 +39,98 @@ RELEASING:
 ## [v1.0.12] - 2021-04-28 ##
 
 ### Added ###
-
-- Added Hungarian language
+- Hungarian language
 
 ### Changed ###
-
 - Show slider current value as user moves the slider
 
 ## [v1.0.11] - 2021-04-23 ##
 
-### Changed ###
-
-- Fix the processing of filter values that are invalid that were affecting some valid filters
+### Fixed ###
+- the processing of filter values that are invalid and were affecting some valid filters
 
 ## [v1.0.10] - 2021-04-20 ##
 
 ### Changed ###
-
-- Fix typos in places-and-directions
-- Auto close download and settings modal after main action is executed
-- Remove invalid filter values when profile changes
+- Auto close download and settings modal after executing the main action
 - Update map view when in directions mode, a place changes, but there is no valid route yet
-- Only show marker with number inside if a route is being displayed
-- the file `src/config-examples/default-map-settings-example.js` changed. Update your config file based on that.
+- Only show marker with number inside when displaying a route
+- file `src/config-examples/default-map-settings-example.js` (Update your config)
+
+### Fixed
+- typos in places-and-directions
+
+### Removed
+- invalid filter values when profile changes
 
 ## [v1.0.9] - 2021-04-09 ##
 
-### Changed ###
+### Added
+- right click context menu 'Inspect data on OSM'
 
+### Changed ###
 - Keep altitude chart/graph open when route changes
-- Add right click context menu 'Inspect data on OSM'
 
 ## [v1.0.8] - 2021-04-07 ##
 
-### Changed ###
+### Added
+- raw routing (skip all segments) option in advanced settings
+- a field for custom over layer in settings
 
-- Add raw routing (skip all segments) option in advanced settings
-- Add field for custom over layer in settings
-
-The config example src/config-examples/default-map-settings-example.js file was changed. Updated your corresponding config file
+### Changed
+- file `src/config-examples/default-map-settings-example.js` (Update your config)
 
 ## [v1.0.7] - 2021-04-01 ##
 
 ### Changed ###
-
 - Show ascent and descent for each segment on route details component
-- Remove altitude component i18n files, since it is not been used anymore
+
+### Removed
+- altitude component i18n files, since it is not been used anymore
 
 ## [v1.0.6] - 2021-03-25 ##
 
-### Fixed ###
+### Added
+- support for gpx, xml and kml multi segment routes
 
+### Fixed ###
 - Fix building routes as alternative routes in file importer
-- Add support for gpx, xml and kml multi segment routes
 
 ## [v1.0.5] - 2021-03-25 ##
 
 ### Fixed ###
-
-- Stop displaying old route when the route way points change and a new route can not be calculated
-- Build extra info highlight color based on item index or value
+- Stop displaying old route when the route way points changed, and a new route cannot be calculated
+- Build extra info highlight color based on an item index or value
 
 ## [v1.0.4] - 2021-03-24 ##
 
 ### Fixed ###
-
-- Show place markers when the could can not be calculated
+- Show place markers when the route cannot be calculated
 - Show calculating toaster indefinitely (until an error or success toaster replace it)
-- Fix the adding of extra info to the request when a nested profile is active, like foot-hiking
+- the adding of extra info to the request when a nested profile is active, like foot-hiking
 
-### Changed ###
-
-- Remove avoid_feature filters that are not support anymore (update your local ors-map-filters.js)
+### Removed ###
+- avoid_feature filters that are not supported anymore (update your local `ors-map-filters.js`)
 
 ## [v1.0.3] - 2021-03-22 ##
 
 ### Fixed ###
-
 - Fixed admin area loader filter for cases when no locality is available
 
 ## [v1.0.2] - 2021-03-22 ##
 
 ### Added ###
-
 - Support to search by postal code
 
 ### Changed ###
-
-- Auto select by hit enter/return also in the case of a single postal code layer result
-- Template/example file `layer-zoom-mapping-example` was changed to include postal code (please update your config file to reflect this)
+- Auto-select by pressing enter/return also in the case of a single postal code layer result
+- Template/example file `layer-zoom-mapping-example` to include postal code (update your config)
 
 ## [v1.0.1] - 2021-03-18 ##
 
-### Changed ###
+## Added
+- allowing to save default locale as preferred locale
 
+### Changed ###
 - Sidebar foot height
 - About translation in French
-- Allow saving default locale as preferred locale

--- a/docs/search-results-criteria.md
+++ b/docs/search-results-criteria.md
@@ -1,28 +1,52 @@
-# How search result items are defined
+# How search result items are generated
 
-## Understand the case and the need
+## Understand the case and need
 
-The ORM maps client has the search suggestion and the search results. While the suggestion suggest results based on the text inputted, the search results show "all" the results, considering that "all" means a maximum of 100 items. To keep the consistency, we decided that the items showed as suggestions should be among the results when the user decides to see "all" items, by hitting `Enter` or by clicking on the search button. As the results of the `autocomplete` ORS service brings different results, in some cases, when compared to the ORS `geocode/search`, we are using `geocode/search` for both cases.
+The ORS maps client has search suggestion and search results.
+While the suggestion recommend results based on the text inputted, the search results show "all" the results with a
+maximum of 100 items.
+For consistency, items shown as suggestions should be among the results when the user decides to see "all" items,
+by hitting `Enter` or by clicking on the search button.
+As the results of the `autocomplete` ORS service brings different results, in some cases, when compared to the ORS
+`geocode/search`, we are using `geocode/search` for both cases.
 
-In the tests we conducted we noticed that in many cases `geocode/search` does not bring the items in the `venue` layer (that represents POIs or "things" people search for, like a café, a bakery or a school) among the first items. It seems that this happen because in many cases other layers are prioritized and when we have only 10 slots (in the case of search suggestion), they just don't appear in many cases. The `autocomplete` does bring them in many cases, but let's remember that we want to keep the consistence, that is why we are using the same endpoint/service for both (`geocode/search`).
+In the tests we conducted we noticed that in many cases `geocode/search` does not bring the items in the `venue` layer
+(that represents POIs or "things" people search for, like a café, a bakery or a school) among the first items.
+It seems this happens because in many cases other layers are prioritized and when we have only 10 slots
+(in the case of search suggestion), they just don't appear in many cases.
+The `autocomplete` does bring them in many cases, but let's remember that we want to keep the consistence,
+that is why we are using the same endpoint/service for both (`geocode/search`).
 
 ## The perfect match for everyone
 
-Although in many cases there might be a consensus about what should appear and what should come first on a list of suggestions given a text inputted and a focus point, it is common that different users have different opinions about the results. A user that has the map view focused on a city in Germany where there is a bakery named "Berlin" could expect to see on the top of the list the "Berlin Bakery" while another user in the same city could expect to see on the top of the list the city of Berlin, even if Berlin, in this fictitious case, is hundreds of kms away.
+Although in many cases there might be a consensus about what should appear and what should come first on a list of
+suggestions when given a text input as well as a focus point, usually different users have different opinions about
+the results.
+A user that has the map view focused on a city in Germany where there is a bakery named "Berlin" could expect to see
+on the top of the list the "Berlin Bakery" while another user in the same city could expect to see on the top of the
+list the city of Berlin, even if Berlin, in this fictitious case, is hundreds of kms away.
 
-Similar and more complex cases happen, like someone searching for a street that has the same name of city. In some cases there are several streets with the same name and venues with that name. Some search returns a kind of pollution with lots of streets, but no venues, while in some cases lots of cities and no street. We could go on and depict several cases that might not be the bst result.
+Similar and more complex cases happen, like someone searches for a street, which has the same name as a city.
+In some cases there are several streets with the same name and venues with that name.
+Some search returns a kind of pollution with lots of streets, but no venues, while in some cases lots of cities and
+no street.
+We could go on and depict several cases that might not be the best result.
 
 ## The goal of the ORS maps search
 
-The goal is to have, among the suggested items, a mix of cities, addresses, venues, countries and other layers. At the same time, we want to keep on the top what is considered the best match. We want to represent on this list what is more important when the local and the global scopes are considered (a local POI and a city in another country)
+The goal is to have, among the suggested items, a mix of cities, addresses, venues, countries and other layers.
+At the same time, we want to keep on the top what is considered the best match.
+We want to represent on this list what is more important when considering local and global scopes
+(a local POI and a city in another country).
 
 ## The solution implemented
 
-As the `geocode/search` does not accept a parameter telling the layer priorities and the amount of items per layer, we ended up implementing a solution that composes the results of three searches. The following steps describe the solution:
+As the `geocode/search` does not accept a parameter for layer priorities, or the amount of items per layer,
+the current implementation creates results by doing three searches:
 
-- (1) - A search for items in the `locality` layer is run, passing a focus point
-- (2) - A search for items in the other layers, except `locality` and `venue` is run.
-- (3) - A search for items in the `venue` layer, that are within the current map view bounds is run.
+1. A search for items in the `locality` layer, passing a focus point
+1. A search for items in the other layers, except `locality` and `venue`
+1. A search for items in the `venue` layer, that are within the current map view bounds
 
 Having the results of the three searches, the app merges them using the following rules:
 
@@ -32,22 +56,37 @@ Having the results of the three searches, the app merges them using the followin
 
 Important: *If some searches do not bring results, the empty slots are filled with extra items from the other searches*
 
-Then the results are ordered by distance (considering the current map center) and some items are moved to certain positions:
+Then the results are ordered by distance (considering the current map center), and some items are moved to certain
+positions:
 
 - if the search (1) brought results, its first item is moved to the `second` position
 - if the search (2) brought results, the best match (item in position 0) is put on the `top of the list`
-- if the search (2) brought results and there is a result that is on the `country` layer, it is moved to the third position (if it is not already the best match)
+- if the search (2) brought results and there is a result that is on the `country` layer,
+it is moved to the third position (if it is not already the best match)
 
-With this solution it seems that we could find a good balance and considering the possibilities and what the API offers fulfill the expectations of the most of the users. We do understand that there might be specific cases where the results presented are not the ones expected by the user. If we identify them, then we will re-evaluate/improve this strategy.
+With this solution it seems that we could find a good balance and considering the possibilities and what the API offers
+fulfill the expectations of the most of the users.
+We do understand that there might be specific cases where the results presented are not the ones expected by the user.
+If we identify them, then we will re-evaluate/improve this strategy.
 
 ## Comparison with other clients/services
 
-It is important to highlight that we don't capture/user the same data that other commercial apps do to decide what is the best match for individual users. Some applications on the market have access to many user-specific data as well as statistics that help them to determine the best match. This commercial tools might have access or use data like:
+It is important to highlight that we don't capture/user the same data that other commercial apps do to decide what is
+the best match for individual users.
+Some applications on the market have access to many user-specific data as well as statistics that help them to
+determine the best match.
+This commercial tools might have access or use data like:
 
 - search history (even outside the maps client)
-- search patterns (people on a certain location, with a certain language defined, in certain time span or season tends to find xx results better)
+- search patterns (people on a certain location, with a certain language defined, in certain time span or season tends
+to find xx results better)
 - user location history
 - user recent interactions with pages that has some connection with the service provider
 - user recent dialogs (captured by a mobile microphone, for example)
 
-The list is could be easily extended. These are just some examples. All this very intrusive and data intense analysis might result in better place search results in some cases and they might appear to be perfect for many users. But the services the ORS maps client use have a different approach. Our goal is to provide the best possible results, considering the few data that the app sends to the service: current map center/bounds, text inputted and browser language.
+The list could easily be extended. These are just some examples.
+All this very intrusive and data intense analysis might result in better place search results in some cases, and they
+might appear to be perfect for many users.
+The services the ORS maps client use have a different approach.
+Our goal is to provide the best possible results, considering the few data that the app sends to the service:
+current map center/bounds, text inputted and browser language.

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,7 +11,7 @@
       </transition>
     </v-content>
     <app-sidebar :class="{'a11y' : $store.getters.mapSettings.acessibleModeActive}"></app-sidebar>
-    <!-- For instance, we will display n app footer, because the want a full heigh map view -->
+    <!-- For instance, we will display n app footer, because the want a full height map view -->
     <!-- <app-footer v-if="$store.getters.displayFooter"></app-footer> -->
   </v-app>
 </template>

--- a/src/app-loader.js
+++ b/src/app-loader.js
@@ -30,9 +30,9 @@ const fetchApiInitialData = () => {
           saveApiData(appConfig.orsApiKey, constants.endpoints)
           resolve()
         } else {
-          let httpClient = new HttpClient({baseURL: appConfig.dataServiceBaseUrl})          
-          // Request the public API key from the remote service 
-          // (only works when runing the app on valid ORS domains).
+          let httpClient = new HttpClient({baseURL: appConfig.dataServiceBaseUrl})
+          // Request the public API key from the remote service
+          // (only works when running the app on valid ORS domains).
           // If the request fails, use the local user key instead
           httpClient.http.get(appConfig.publicApiKeyUrl).then(response => {
             saveApiData(response.data, constants.publicEndpoints)
@@ -50,8 +50,8 @@ const fetchApiInitialData = () => {
 
 /**
  * Find the fitting locale
- * @param {String} mapSettings 
  * @returns {String}
+ * @param storedLocale
  */
 const setFittingLocale = (storedLocale) => {
   var deviceLocale = window.navigator.language || window.navigator.userLanguage
@@ -62,7 +62,7 @@ const setFittingLocale = (storedLocale) => {
   let isLocaleValid = lodash.find(settingsOptions.appLocales, (l) => {
     return l.value === locale
   })
-  // If the exact locale of the device is not available, try at least to use the language 
+  // If the exact locale of the device is not available, try at least to use the language
   if (!isLocaleValid) {
     let language = locale
     if (locale.length > 2 && locale.indexOf('-') > -1) {
@@ -73,7 +73,7 @@ const setFittingLocale = (storedLocale) => {
     })
     if (isLocaleValid) {
       locale = isLocaleValid.value
-    }    
+    }
   }
   // If the selected locale is not supported, set the default
   if (!isLocaleValid) {
@@ -83,9 +83,8 @@ const setFittingLocale = (storedLocale) => {
 }
 /**
  * Save the API data
- * @param {*} commit 
- * @param {*} apiKey 
- * @param {*} endpoints 
+ * @param {*} apiKey
+ * @param {*} endpoints
  */
 const saveApiData = (apiKey, endpoints) => {
   // Save the api key and the endpoints to the default settings object
@@ -121,7 +120,7 @@ const saveApiData = (apiKey, endpoints) => {
     // If the settings was saved in local storage
     // then this option is must start as true
     mapSettings.saveToLocalStorage = true
-  }  
+  }
   storeLocale(mapSettings, locale)
 
   let mainVue = main
@@ -138,8 +137,8 @@ const saveApiData = (apiKey, endpoints) => {
 
 /**
  * Store the map settings locale and routing locale
- * @param {*} mapSettings 
- * @param {*} locale 
+ * @param {*} mapSettings
+ * @param {*} locale
  */
 const storeLocale = (mapSettings, locale = null) => {
   let fittingLocale = setFittingLocale(locale)
@@ -152,7 +151,7 @@ const storeLocale = (mapSettings, locale = null) => {
     settingsOptions.routingInstructionsLocale = locale
   } else {
     validroutingLocale = lodash.find(settingsOptions.routingInstructionsLocales, (l) => {
-      return l.value === fittingLocale.split('-')[0]     
+      return l.value === fittingLocale.split('-')[0]
     })
     if (validroutingLocale) {
       mapSettings.routingInstructionsLocale = validroutingLocale.value
@@ -164,9 +163,6 @@ const storeLocale = (mapSettings, locale = null) => {
 }
 /**
  * check if the embed is in the url params and set the embed state
- * @param {*} getters 
- * @param {*} commit 
- * @param {*} routeTo 
  */
 const checkAndSetEmbedState = () => {
   return new Promise((resolve) => {
@@ -179,7 +175,7 @@ const checkAndSetEmbedState = () => {
       locale = setFittingLocale(locale)
 
       let settings = store.getters.mapSettings
-      storeLocale(settings, locale) 
+      storeLocale(settings, locale)
     }
     resolve(isEmbed)
   })

--- a/src/config-examples/app-config-example.js
+++ b/src/config-examples/app-config-example.js
@@ -1,4 +1,4 @@
-// This is an example file and is expected to be cloned 
+// This is an example file and is expected to be cloned
 // without the -example on the same folder that it resides.
 
 // You can change the value of a property (using a supported value), but you shouldn't remove a property
@@ -10,7 +10,7 @@ const appConfig = {
   footerDevelopedByLink: 'https://www.heigit.org/', // The url that is used on the footer developed by link
   urlMode: 'hash', // The url mode for vue router: `hash` or `history`
   baseAppUrl: '/', // Could be, for example, '/map' if your app is running in a folder under a domain
-  dataServiceBaseUrl: 'https://openrouteservice.org/wp-json/', // The base data url to retrive ORS data (Don't change this unless you know what your doing!)
+  dataServiceBaseUrl: 'https://openrouteservice.org/wp-json/', // The base data url to retrieve ORS data (Don't change this unless you know what your doing!)
   maxPlaceInputs: 50, // The ORS API support max 50 points
   appMenu: {
     useORSMenu: true, // If the default ORS menu must be used
@@ -32,26 +32,26 @@ const appConfig = {
   showAltitudeOnSidebar: true, // show altitude preview on sidebar
 
   autoSelectFirstExactAddressMatchOnSearchEnter: true, // If the first exact address match must be auto selected when the user type a text and in the place search and hit enter/return
-  
+
   disabledActionsForIsochrones: ['roundtrip'], // Possible values: `addPlaceInput`, `clearPlaces`, `reverseRoute`, `roundtrip`, `routeImporter`
   disabledActionsForPlacesAndDirections: [], // // Possible values: `addPlaceInput`, `clearPlaces`, `reverseRoute`, `roundtrip`, `routeImporter`
   supportsPlacesAndDirections: true, // If thw whole places and directions feature is supported/enabled in the application
   supportsIsochrones: true, // If isochrones is supported/enabled in the application
   supportsMapFiltersOnSidebar: true, // if the filters options box is present/enabled in the app
-  supportsDirections: true, // If the directions funcionality is available
-  sidebarStartsOpenInHeighResolution: false, // if the sidebar must start open in heigh resolution
+  supportsDirections: true, // If the directions functionality is available
+  sidebarStartsOpenInHighResolution: false, // if the sidebar must start open in high resolution
   defaultTilesProvider: 'osm', // The default tile provider  (valid values are the `id` property of one of the `mapTileProviders` array below)
   supportsAvoidPolygonDrawing: true, // If the avoid polygon drawing tools must be available on the map view
   distanceMeasureToolAvailable: true, // If the polyline distance measure tool must be available on the map view
-  accessbilityToolAvailable: true, // If the accessibility tool must be available on the map view
+  accessibilityToolAvailable: true, // If the accessibility tool must be available on the map view
   fitAllFeaturesToolAvailable: true, // If the fitAllFeatures to0l must be available on the map view
-  supportsClusteredMarkers: true, // If clusted markers is supported (then markers with `clustered=true` property will be clustered)
+  supportsClusteredMarkers: true, // If clustered markers is supported (then markers with `clustered=true` property will be clustered)
   supportsSearchBottomCarousel: true, // If the bottom carousel with the search results must be displayed or not.
   supportsSearchMode: true, // If the search mode is supported
   supportsMyLocationBtn: true, // If the `my location` button is supported on the map view
   initialZoomLevel: 6, // The initial map view zoom level
   initialMapMaxZoom: 18, // The initial map view max zoom
-  
+
 
   // The map tile providers available. At least one must be present
   mapTileProviders: [

--- a/src/config-examples/hooks-example.js
+++ b/src/config-examples/hooks-example.js
@@ -1,4 +1,4 @@
-// This is an example file and is expected to be cloned 
+// This is an example file and is expected to be cloned
 // without the -example on the same folder that it resides.
 
 
@@ -9,18 +9,18 @@ import main from '@/main'
 import PluginExample from '@/plugins/plugin-example/plugin-example.js'
 
 // Create a var that will have a reference to the
-// plugin instante when it is instantiated in 
+// plugin instance when it is instantiated in
 // appLoaded hook defined below.
 var pluginExample
 
 const appHooks = main.getInstance().appHooks
 
 // When adding a hook, three parameters can be passed:
-// the name of the hook (string) to be listened, the 
+// the name of the hook (string) to be listened, the
 // function to be run and the priority (number).
 
 // Below are examples of hook event that happen in the app.
-// Some behaviors of the app can be modified by changing the 
+// Some behaviors of the app can be modified by changing the
 // parameter value that is passed when the hook is run.
 
 appHooks.add('appLoaded', (vueInstance) => {
@@ -31,13 +31,13 @@ appHooks.add('appLoaded', (vueInstance) => {
   let locale = vueInstance.$i18n.locale
   let messages = vueInstance.$i18n.messages[locale]
   messages.placeInput.findAPlace = 'Custom place input'
-  vueInstance.$i18n.setLocaleMessage(locale, messages) 
+  vueInstance.$i18n.setLocaleMessage(locale, messages)
 }, 1)
 
-// The catch all hook allows, as the name says, cathing all
+// The catch all hook allows, as the name says, catching all
 // the hooks. It receives as parameters not only the hook parameter
-// arg, but also the hook name. It can be used to run plugin functions 
-// with the same name of the hook. By using this hook in combination with 
+// arg, but also the hook name. It can be used to run plugin functions
+// with the same name of the hook. By using this hook in combination with
 // a plugin you avoid having to define every hook individually and inside
 // these hooks call a plugin method/function.
 
@@ -51,7 +51,7 @@ appHooks.add('catchAll', (hookName, hookData) => {
 
 // #### INDIVIDUAL HOOKS DEFINITION ###
 
-// If you want to define the hooks individually, 
+// If you want to define the hooks individually,
 // then the templates are shown below.
 
 appHooks.add('mapViewDataChanged', (mapViewData) => {
@@ -60,8 +60,8 @@ appHooks.add('mapViewDataChanged', (mapViewData) => {
 
 appHooks.add('mapReady', (hookData) => {
   // hookData has the following structure {context: Object, map: Object}
-  // custom map controls/components can be added via map objects 
-  // or via hookData.context.customMapControlsContainer (a vue ref for an emptyy container inside the map view)
+  // custom map controls/components can be added via map objects
+  // or via hookData.context.customMapControlsContainer (a vue ref for an empty container inside the map view)
   pluginExample.mapReady(hookData)
 }, 1)
 
@@ -86,8 +86,8 @@ appHooks.add('placeSelected', (hookData) => {
 // then add two menu items mock p to show that menu  is working
 appHooks.add('modifyMenu', (menu) => {
   // If in app settings is set not  to load/use ORS menu items, then
-  // two items will be added to the menu as a sample. It is just to 
-  // demonstrate that the menu is workin. You can remove the code 
+  // two items will be added to the menu as a sample. It is just to
+  // demonstrate that the menu is working. You can remove the code
   // below if you want an empty menu or customize the item of the menu.
   if (!appConfig.appMenu.useORSMenu) {
     menu.push({
@@ -107,7 +107,7 @@ appHooks.add('modifyMenu', (menu) => {
   }
 }, 1)
 
-// The hooks below are just for demonstration about what 
+// The hooks below are just for demonstration about what
 // can be used. If you are not using, you can remove them.
 appHooks.add('afterGetRouteOptions', (options) => {
   // Do something when the route options is built
@@ -189,12 +189,12 @@ appHooks.add('poisMarkersCreated', (markers) => {
   return markers
 }, 1)
 
-// When markers that represent the 
+// When markers that represent the
 // routing places or searched places are created
 appHooks.add('markersCreated', (markers) => {
   // Do something
 
-  // Code example for customizing icons using material desing icons https://material.io/resources/icons/
+  // Code example for customizing icons using material design icons https://material.io/resources/icons/
 
   // ### BEGINNING OF EXAMPLE
 
@@ -204,7 +204,7 @@ appHooks.add('markersCreated', (markers) => {
   //   let markerColor = '#c30b82' // maybe change the color based on the place properties ?
   //  let iconDivMarkerStyle = `width: 30px;height: 30px;border-radius: 50% 50% 50% 0;background: ${markerColor};position: absolute;transform: rotate(-45deg);left: 50%;top: 50%;margin: -15px 0 0 -15px;`
   //  let markerIcon = 'hotel' // maybe change the icon based on the place properties ?
-    
+
   //  markers[key].icon = Leaflet.divIcon({
   //    className: 'custom-div-icon',
   //    html: `<div style='${iconDivMarkerStyle}'><i style='${markerIcoStyle}' class='material-icons'>${markerIcon}</i></div>`,
@@ -256,7 +256,7 @@ appHooks.add('beforeOpenMarkerPopup', (hookData) => {
   // hookData has the following structure {marker: Object, markerPopupContainer: HtmlNode}
   // `markerPopupContainer` is an HTML node and can be manipulated.
   // It possible to remove and change existing content, as well
-  // as add new vuejs component. See the example below.
+  // as add new vue component. See the example below.
 
   // ### BEGINNING OF EXAMPLE
 
@@ -267,36 +267,36 @@ appHooks.add('beforeOpenMarkerPopup', (hookData) => {
   // the line below would remove the inner html
 
   // markerPopupContainer.innerHTML = ''
-  
+
   // this hook will be invoked every time the popup is about
   // to render. So, to avoid content multiple times
   // we check it the component was not already added
-  
+
   //let buttons = markerPopupContainer.querySelectorAll('a')
 
-  // If the vuejs component was not already added
+  // If the vue component was not already added
   // if (buttons.length == 0) {
-  // Don't forget to the the imports in the header 
-  // for this example, it would be: 
+  // Don't forget to the the imports in the header
+  // for this example, it would be:
   // import Vue from 'vue'
   // import {VBtn} from 'vuetify'
-  //  var ComponentClass = Vue.extend(VBtn) // don't forget to add 
+  //  var ComponentClass = Vue.extend(VBtn) // don't forget to add
   //  var instance = new ComponentClass({ propsData: { color: 'primary' } })
   //  instance.$slots.default = [ 'Click me!' ]
   //  instance.$on(['click'], e => { console.log('event', e) })
   //  instance.$mount() // pass nothing
-   
-    // Finnaly append the instantiated vue 
+
+    // Finally append the instantiated vue
     // component to the markerPopupContainer
     // markerPopupContainer.appendChild(instance.$el)
-  // } 
+  // }
   // ### END OF EXAMPLE
 }, 1)
 
 appHooks.add('beforeShowResolvedPlaceInfo', (hookData) => {
-  
-  // hookData has the following structure: 
-  // { 
+
+  // hookData has the following structure:
+  // {
   //  placeInfo: { placeName: String, containerArea: String, clickInsidePolygon: Boolean, latlng: {lat:..., lng:...}},
   //  placeInfoContainer: HtmlNode
   // }
@@ -306,14 +306,14 @@ appHooks.add('beforeShowResolvedPlaceInfo', (hookData) => {
   // the the hideDirectionsTo btn is not shown
 
   // It possible to remove and change existing content, as well
-  // as add new vuejs component in the popupHtmlFragment. 
+  // as add new vue component in the popupHtmlFragment.
   // See the example in `beforeOpenMarkerPopup`
 }, 1)
 
 appHooks.add('beforeShowAvoidPolygonPopup', (hookData) => {
   // hookData has the following structure {polygon: Object, popupHtmlFragment: HtmlNode}
   // It possible to remove and change existing content, as well
-  // as add new vuejs component in the popupHtmlFragment. 
+  // as add new vue component in the popupHtmlFragment.
   // See the example in `beforeOpenMarkerPopup`
 }, 1)
 
@@ -338,7 +338,7 @@ appHooks.add('beforeOpenIsochronePopup', (hookData) => {
   // hookData has the following structure {polygon: Object, isochronePopupContainer: HtmlNode}
   // isochronePopupContainer = an HTML node and can be manipulated,
   // It possible to remove and change existing content, as well
-  // as add new vuejs component. See the example below.
+  // as add new vue component. See the example below.
   // See the example in `beforeOpenMarkerPopup`
   // Do something
 }, 1)
@@ -363,8 +363,8 @@ appHooks.add('placeSearchResultPrepared', (places) => {
 })
 
 appHooks.add('placeSearchPromisesDefined', (promises) => {
-  // Two promises, one for address/admistrative localities and other for venus are created.
-  // You could pottentially replace one of them or both for custom requests.
+  // Two promises, one for address/administrative localities and other for venus are created.
+  // You could potentially replace one of them or both for custom requests.
 
   // ### BEGINNING OF EXAMPLE
   // let filters = { category_group_ids: [100] } // define a category that would be searched
@@ -377,7 +377,7 @@ appHooks.add('placeSearchPromisesDefined', (promises) => {
 appHooks.add('beforeUseMarkerClusterOptions', (options) => {
   // Do something
 
-  // An options object must bereturned
+  // An options object must be returned
   return options
 })
 

--- a/src/config-examples/ors-map-filters-example.js
+++ b/src/config-examples/ors-map-filters-example.js
@@ -1,4 +1,4 @@
-// This is an example file and is expected to be cloned 
+// This is an example file and is expected to be cloned
 // without the -example on the same folder that it resides.
 
 import routeSmoothnessList from '@/resources/lists/route-smoothness'
@@ -8,7 +8,7 @@ import gradesList from '@/resources/lists/grades'
 import constants from '@/resources/constants'
 
 const filters = [
-  { // Profile filter is required. What you can change is the avaialble items in the enum and mapping
+  { // Profile filter is required. What you can change is the available items in the enum and mapping
     name: 'profile',
     useInServices: [constants.services.directions, constants.services.isochrones],
     hidden: true,
@@ -196,13 +196,13 @@ const filters = [
         type: constants.filterTypes.wrapper,
         useInServices: [constants.services.directions],
         availableOnModes: [constants.modes.roundTrip, constants.modes.directions],
-        valueAsObject: true,     
+        valueAsObject: true,
         validWhen: [
           {
             ref: 'profile',
             value: ['driving-hgv', 'wheelchair']
           }
-        ],   
+        ],
         props: [
           {
             name: 'restrictions',
@@ -225,7 +225,7 @@ const filters = [
                     ref: 'self',
                     min: 1
                   }
-                ], 
+                ],
                 value: 0,
                 min: 1,
                 max: 100,
@@ -245,7 +245,7 @@ const filters = [
                     ref: 'self',
                     min: 2
                   }
-                ], 
+                ],
                 value: 0,
                 min: 2,
                 max: 5,
@@ -265,7 +265,7 @@ const filters = [
                     ref: 'self',
                     min: 2
                   }
-                ], 
+                ],
                 value: 0,
                 min: 2,
                 max: 15,
@@ -281,7 +281,7 @@ const filters = [
                     ref: 'profile',
                     value: 'driving-hgv'
                   }
-                ], 
+                ],
                 value: 0,
                 min: 1,
                 max: 100,
@@ -297,7 +297,7 @@ const filters = [
                     ref: 'profile',
                     value: 'driving-hgv'
                   }
-                ], 
+                ],
                 value: 0,
                 min: 2,
                 max: 5,
@@ -312,7 +312,7 @@ const filters = [
                     ref: 'profile',
                     value: 'driving-hgv'
                   }
-                ], 
+                ],
                 value: false,
               },
               {
@@ -324,7 +324,7 @@ const filters = [
                     ref: 'profile',
                     value: 'wheelchair'
                   }
-                ], 
+                ],
                 value: '6',
                 isEnum: true,
                 enum: [
@@ -343,7 +343,7 @@ const filters = [
                     ref: 'profile',
                     value: 'wheelchair'
                   }
-                ], 
+                ],
                 isEnum: true,
                 value: '0.06',
                 enum: [
@@ -362,7 +362,7 @@ const filters = [
                     ref: 'profile',
                     value: 'wheelchair'
                   }
-                ], 
+                ],
                 value: 1,
                 min: 0,
                 max: 30,
@@ -377,10 +377,10 @@ const filters = [
                     ref: 'profile',
                     value: 'wheelchair'
                   }
-                ], 
+                ],
                 isEnum: true,
                 value: 'good',
-                items: routeSmoothnessList,                
+                items: routeSmoothnessList,
                 itemValue: 'value'
               },
               {
@@ -392,10 +392,10 @@ const filters = [
                     ref: 'profile',
                     value: 'wheelchair'
                   }
-                ], 
+                ],
                 isEnum: true,
                 value: 'cobblestone',
-                items: surfaceTypesList,                
+                items: surfaceTypesList,
                 itemValue: 'value'
               },
               {
@@ -407,10 +407,10 @@ const filters = [
                     ref: 'profile',
                     value: 'wheelchair'
                   }
-                ], 
+                ],
                 isEnum: true,
                 default: null,
-                value: 'grade1',                
+                value: 'grade1',
                 itemValue: 'value',
                 items: gradesList
               }
@@ -551,7 +551,7 @@ const filters = [
         name: 'avoid_countries',
         required: false,
         type: constants.filterTypes.array,
-        default: false,        
+        default: false,
         itemValue: 'cid',
         apiDefault: false,
         isEnum: true,

--- a/src/directives/smart-tooltip.js
+++ b/src/directives/smart-tooltip.js
@@ -5,7 +5,7 @@ import store from '@/store/store'
 import main from '@/main'
 
 /**
- * Popper tooltip cdirective hanlder
+ * Popper tooltip directive handler
  */
 const smartTooltip = {
   bind (el, binding, vNode) {
@@ -15,7 +15,7 @@ const smartTooltip = {
     if (vNode.context.popperTooltipGuid) {
       closeTooltip(vNode.context.popperTooltipGuid)
     }
-  }, 
+  },
   update (el, binding, vNode) {
     render(el, binding, vNode, true)
   },
@@ -28,7 +28,7 @@ const smartTooltip = {
  * Render the tooltip component
  * @param {*} el - DOM the element which the tooltip will be attached to
  * @param {*} binding - parameters
- * @param {*} vNode - vuejs element which the tooltip will be attached to
+ * @param {*} vNode - vue element which the tooltip will be attached to
  * @param {*} rerendering - if the tooltip is being updated
  */
 const render = (el, binding, vNode, rerendering = false) => {
@@ -48,9 +48,9 @@ const render = (el, binding, vNode, rerendering = false) => {
 
 /**
  * Handle the close tooltip click
- * @param {*} tooltipGuid 
- * @param {*} hidePermantely 
- * @param {*} name 
+ * @param {*} tooltipGuid
+ * @param {*} hidePermantely
+ * @param {*} name
  */
 const closeTooltip = (tooltipGuid, hidePermantely, name) => {
   removeTooltipEl(tooltipGuid)
@@ -62,11 +62,11 @@ const closeTooltip = (tooltipGuid, hidePermantely, name) => {
 
 /**
  * Remove tooltip rom DOM
- * @param {*} tooltipGuid 
+ * @param {*} tooltipGuid
  */
 const removeTooltipEl = (tooltipGuid) => {
   if (tooltipGuid) {
-    let tooltipEl = document.getElementById(tooltipGuid)  
+    let tooltipEl = document.getElementById(tooltipGuid)
     if (tooltipEl) {
       document.body.removeChild(tooltipEl)
     }
@@ -75,7 +75,7 @@ const removeTooltipEl = (tooltipGuid) => {
 
 /**
  * Store in browser's local storage that the the tooltip has already been shown
- * @param {*} tooltipName 
+ * @param {*} tooltipName
  */
 const storeTooltipAlreadyShown = (tooltipName) => {
   let mapSettings = store.getters.mapSettings
@@ -90,14 +90,14 @@ const storeTooltipAlreadyShown = (tooltipName) => {
  * Show tooltip
  * @param {*} el - DOM the element which the tooltip will be attached to
  * @param {*} options tool tip options object
- * @param {*} vNode - vuejs element which the tooltip will be attached to
+ * @param {*} vNode - vue element which the tooltip will be attached to
  */
 const showToolTip = (el, options, vNode) => {
-  vNode.context.$nextTick(() => {    
+  vNode.context.$nextTick(() => {
     var mustBeShown = true
-    // Check if tool tip was already showm
+    // Check if tool tip was already shown
     if ((options.showOnce || options.saveClose) && options.name) {
-      let mapSettings = store.getters.mapSettings      
+      let mapSettings = store.getters.mapSettings
       mustBeShown = !(mapSettings.shownOnceTooltips && mapSettings.shownOnceTooltips[options.name])
     }
     if (options.showOnce && !appConfig.showInstructionsTooltipsOnFirstLoad) {
@@ -122,16 +122,16 @@ const showToolTip = (el, options, vNode) => {
       let toolTipEl = buildTooltipEl(guid, options)
       document.body.appendChild(toolTipEl)
       setArrowPseudoStyles(guid, options)
-      
+
       // Build tooltip popper options
       let popperOptions = { placement: options.position, modifiers: [{ name: 'offset', options: { offset: [0, 8] } } ]  }
-      
-      // Store the tooltip unique id in the vuejs component
+
+      // Store the tooltip unique id in the vue component
       vNode.context.popperTooltipGuid = guid
 
       // Create the popper tooltip
-      createPopper(el, toolTipEl, popperOptions) 
-      
+      createPopper(el, toolTipEl, popperOptions)
+
       // Ir the tooltip must be shown only once
       // then store that it was already shown
       if (options.showOnce) {
@@ -143,8 +143,8 @@ const showToolTip = (el, options, vNode) => {
 
 /**
  * Build tooltip el html fragment
- * @param {*} guid 
- * @param {*} options 
+ * @param {*} guid
+ * @param {*} options
  * @returns {HtmlFragment}
  */
 const buildTooltipEl = (guid, options) => {
@@ -166,13 +166,13 @@ const buildTooltipEl = (guid, options) => {
   toolTipContentEl.className = 'popper-tooltip-content'
 
   let style = `
-    z-index:4; 
-    background-color: ${background}; 
-    color: ${contentColor}; 
-    padding: 5px 10px; 
-    border-radius: 4px; 
-    font-size: 13px; 
-    max-width: 200px; 
+    z-index:4;
+    background-color: ${background};
+    color: ${contentColor};
+    padding: 5px 10px;
+    border-radius: 4px;
+    font-size: 13px;
+    max-width: 200px;
     box-shadow: 0px 2px 1px 2px rgba(0,0,0,0.2), 0px 1px 1px 0px rgba(0,0,0,0.14), 0px 1px 3px 0px rgba(0,0,0,0.12);`
 
   let toolTipEl = document.createElement('div')
@@ -180,35 +180,35 @@ const buildTooltipEl = (guid, options) => {
   toolTipEl.setAttribute("style", style)
   toolTipEl.setAttribute("role", 'tooltip')
   toolTipEl.className = 'popper-tooltip'
-  
+
   toolTipEl.innerHTML = `<div id="arrow-${guid}" data-popper-arrow></div>`
   toolTipEl.appendChild(toolTipCloseEl)
   toolTipEl.appendChild(toolTipContentEl)
-  
+
   return toolTipEl
 }
 
 /**
  * Set the tooltip pseudo style by adding an style element to the DOM
- * @param {*} guid 
- * @param {*} options 
+ * @param {*} guid
+ * @param {*} options
  */
 const setArrowPseudoStyles = (guid, options) => {
   let arrowDivId = `arrow-${guid}`
   let styleElem = document.head.appendChild(document.createElement("style"));
   let positionStyle = buildArrowPosition(options)
   let arrowColor = options.dark === true ? '#333;' : 'white'
-  
+
   styleElem.innerHTML = `
     #${arrowDivId} {${positionStyle}}
     #${arrowDivId}, #${arrowDivId}::before {position: absolute;width: 8px;height: 8px;z-index: -1; background: transparent;}
-    #${arrowDivId}:before {content: ''; transform: rotate(45deg); background: ${arrowColor};}    
+    #${arrowDivId}:before {content: ''; transform: rotate(45deg); background: ${arrowColor};}
     `
 }
 
 /**
  * Build the tooltip arrow position style
- * @param {String} options 
+ * @param {String} options
  * @returns {string} arrowPosition
  */
 const buildArrowPosition = (options) => {

--- a/src/fragments/charts/altitude/altitude-parser.js
+++ b/src/fragments/charts/altitude/altitude-parser.js
@@ -2,7 +2,7 @@ import theme from '@/config/theme'
 import lodash from 'lodash'
 
 /**
- * Get the  colums from the the mapviewdata @see src/models/map-view-data
+ * Get the  columns from the the mapViewData @see src/models/map-view-data
  * @param {*} mapViewData
  */
 const getColumns = (mapViewData, routeIndex) => {
@@ -16,7 +16,7 @@ const getColumns = (mapViewData, routeIndex) => {
 }
 
 /**
- * Get the datasets from the mapviewdata @see src/models/map-view-data
+ * Get the datasets from the mapViewData @see src/models/map-view-data
  * @param {*} mapViewData
  */
 const getDatasets = (mapViewData, routeIndex, translations) => {

--- a/src/fragments/forms/fields-container/components/form-fields/form-fields.js
+++ b/src/fragments/forms/fields-container/components/form-fields/form-fields.js
@@ -74,7 +74,7 @@ export default {
       return show
     },
     /**
-     * Set a ne random value for the randon component
+     * Set a ne random value for the random component
      * @param {*} index
      */
     setNewRandomValue (index) {
@@ -148,8 +148,8 @@ export default {
       // There may be nested levels of paternity and these levels
       // must be represented in the parent index property.
       // When the passing data already has a parent index, then
-      // parentIndex will be an array containing the imediate parent
-      // at index 0 and all the acentry at the position 1.
+      // parentIndex will be an array containing the direct parent
+      // at index 0 and all the ancestry at the position 1.
       if ((Array.isArray(data.parentIndex) || data.parentIndex >= 0) && this.parentIndex >= 0) {
         passingData.parentIndex = [data.parentIndex, this.parentIndex]
       } else { // if it is a single level paternity, just set the immediate parent
@@ -250,14 +250,14 @@ export default {
       } else {
         items = parameter.enum
       }
-      
+
       return this.adjustItems(items, parameter)
     },
 
     /**
      * Set item option structure and translation
-     * @param {Array} items 
-     * @return {Array} items 
+     * @param {Array} items
+     * @return {Array} items
      */
     adjustItems (items, parameter) {
       for (let key in items) {
@@ -270,14 +270,14 @@ export default {
                 item[itemKey] = item[itemKey].toString()
               }
             }
-            // If the item object has texts for the current locale, get it and then set it as the itemtext
+            // If the item object has texts for the current locale, get it and then set it as the item text
             item.itemText = item[this.$store.getters.mapSettings.locale] || item[defaultMapSettings.locale] || item.itemValue
           } else { // item is not an object, but a simple value
             let itemObj = {
               itemValue: item,
               itemText: this.getItemTranslation(item, parameter)
             }
-            items[key] = itemObj          
+            items[key] = itemObj
           }
         }
       }
@@ -286,7 +286,7 @@ export default {
 
     /**
      * Get item translation by item value
-     * @param {String} itemValue 
+     * @param {String} itemValue
      * @returns {String}
      */
     getItemTranslation (itemValue, parameter) {
@@ -497,14 +497,14 @@ export default {
           break
         }
       }
-      // By returning O, it is kept open and 
+      // By returning O, it is kept open and
       // by returning null it is kept collapsed
       return childHascontent ? 0 : null
     }
   },
   components: {
     SliderCombo,
-    // Avoid cyclic dependency by loading components assinchronously
+    // Avoid cyclic dependency by loading components asynchronously
     'dialog-fields': () => import('../dialog-fields/DialogFields.vue'),
     'form-fields': () => import('./FormFields.vue')
   }

--- a/src/fragments/forms/fields-container/components/slider-combo/slider-combo.js
+++ b/src/fragments/forms/fields-container/components/slider-combo/slider-combo.js
@@ -29,7 +29,7 @@ export default {
   },
   methods: {
     /**
-     * Run a fieldupdate with a debounce
+     * Run a field update with a debounce
      */
     debounceTextFieldChange () {
       const context = this
@@ -69,9 +69,9 @@ export default {
       this.filter.value = this.textLocalModel = this.localModel
       this.fieldUpdated()
     },
-    
+
     /**
-     * Build slider componet label
+     * Build slider component label
      * @returns {String} unit
      */
     buildUnit () {
@@ -84,7 +84,7 @@ export default {
         unit = String(unit)
       }
       return unit
-    },   
+    },
 
     /**
      * Emit the field update event
@@ -93,6 +93,6 @@ export default {
      */
     fieldUpdated () {
       this.$emit('change', this.localModel)
-    }    
+    }
   }
 }

--- a/src/fragments/forms/map-form/components/form-actions/form-actions.js
+++ b/src/fragments/forms/map-form/components/form-actions/form-actions.js
@@ -24,7 +24,7 @@ export default {
   },
   computed: {
     /**
-     * Determines if a place input can be aded to the view
+     * Determines if a place input can be added to the view
      * @returns boolean
      */
     canAddPlaceInput () {

--- a/src/fragments/forms/map-form/components/isochrones/isochrones.js
+++ b/src/fragments/forms/map-form/components/isochrones/isochrones.js
@@ -159,7 +159,7 @@ export default {
     },
     /**
      * Set a a suggested place as the selected one for a given place input
-     * @param {*} data - can be the palce object or an object containing the place
+     * @param {*} data - can be the place object or an object containing the place
      */
     selectPlace (data) {
       if (data.place) {
@@ -271,7 +271,7 @@ export default {
      */
     handleCalculateIsochronesError (result) {
       this.$root.appHooks.run('beforeHandleIsochronesError', result)
-      
+
       const errorCode = this.lodash.get(result.response, constants.responseErrorCodePath)
       if (errorCode) {
         const errorKey = `isochrones.apiError.${errorCode}`
@@ -294,7 +294,7 @@ export default {
      */
     loadData () {
       if (this.$store.getters.mode === constants.modes.isochrones) {
-        // Emtpy the array and populate it with the
+        // Empty the array and populate it with the
         // places from the appRoute without changing the
         // object reference because it is a prop
         this.places = this.$store.getters.appRouteData.places

--- a/src/fragments/forms/map-form/components/map-form-mixin.js
+++ b/src/fragments/forms/map-form/components/map-form-mixin.js
@@ -45,7 +45,7 @@ export default {
   methods: {
     /**
      * If the active state changes
-     * reset the palces array
+     * reset the places array
      * @param {Boolean} isActive
      */
     activeChanged (isActive) {
@@ -89,7 +89,7 @@ export default {
     */
    removePlace (data) {
     if (this.places[data.index]) {
-      // call the specilized script method
+      // call the specialized script method
       this.removePlaceInput(data.index)
       this.updatePlaceView(data.index)
     }

--- a/src/fragments/forms/map-form/components/place-and-directions/components/route-details/components/extras/route-extras.js
+++ b/src/fragments/forms/map-form/components/place-and-directions/components/route-details/components/extras/route-extras.js
@@ -20,10 +20,10 @@ export default {
   methods: {
     /**
      * Determines if a given
-     * extra must be shown by 
+     * extra must be shown by
      * checking if it is enabled
      * in the app settings
-     * @param {*} extraKey 
+     * @param {*} extraKey
      * @returns {Boolean}
      */
     showExtra (extraKey) {
@@ -50,11 +50,11 @@ export default {
       return extras > 0
     },
     /**
-     * Get the color from the ors dictionary 
+     * Get the color from the ors dictionary
      * based on the extra key and index
-     * @param {*} extraKey 
+     * @param {*} extraKey
      * @param {*} index
-     * @param {*} value 
+     * @param {*} value
      */
     colorValue (extraKey, index, value) {
       let dict = orsDictionary
@@ -62,11 +62,11 @@ export default {
       return color
     },
     /**
-     * Build and return 
+     * Build and return
      * the segment style object
-     * @param {String} extraKey 
-     * @param {Number} amount 
-     * @param {Integer} index 
+     * @param {String} extraKey
+     * @param {Number} amount
+     * @param {Integer} index
      * @returns {Object}
      */
     segmentStyle (extraKey, amount, index) {
@@ -78,8 +78,8 @@ export default {
     },
     /**
      * Get the label of an extra value
-     * @param {String} extraKey 
-     * @param {Integer} value 
+     * @param {String} extraKey
+     * @param {Integer} value
      * @returns {Integer} value
      */
     getExtraValueLabel (extraKey, value) {
@@ -95,12 +95,12 @@ export default {
       return value
     },
     /**
-     * Handle the show section click by 
+     * Handle the show section click by
      * building the object and emitting a
-     * highlightPolylineSections event 
+     * highlightPolylineSections event
      * that will be catch by the map view
      * to highlight a given section of a given extra key
-     * @param {String} extraKey 
+     * @param {String} extraKey
      * @param {Integer} value
      * @param {Integer} index
      * @emits highlightPolylineSections (via eventBus)
@@ -115,12 +115,12 @@ export default {
       this.eventBus.$emit('highlightPolylineSections', heighlighData)
     },
     /**
-     * Handle the show all sections click by 
+     * Handle the show all sections click by
      * building the object and emitting a
-     * highlightPolylineSections event 
+     * highlightPolylineSections event
      * that will be catch by the map view
      * to highlight all sections of a given extra key
-     * @param {String} extraKey 
+     * @param {String} extraKey
      * @emits highlightPolylineSections (via eventBus)
      */
     showAllSections (extraKey) {
@@ -138,27 +138,27 @@ export default {
     },
     /**
      * Build the the extra info highlighting data
-     * @param {String} extraKey 
-     * @param {Integer} index 
+     * @param {String} extraKey
+     * @param {Integer} index
      * @param {Integer} value
      * @returns {Object} {intervals: Array, color: string, label: String}
      */
     buildExtraHighlighPolylineData (extraKey, index, value) {
       const color = this.colorValue(extraKey, index, value)
       const label = this.getExtraValueLabel(extraKey, value).toLowerCase()
-      // Values contains an array with the following data: 
+      // Values contains an array with the following data:
       // a) position `zero` - the starting index on the route polyline array of
       // where the given extra info starts
       // b) position `1` - the final index on the route polyline array where the
       // given extra info ends.
-      // c) position 2 - the value that represents the extra info to be 
-      // swhown on over the route. For example, steepness
+      // c) position 2 - the value that represents the extra info to be
+      // shown on over the route. For example, steepness
       const values = this.routeExtras[extraKey].values
 
-      
+
       // As some extra info may be present in several non-continuous
       // segments we must get the intervals where the value matches
-      // so that we show onlt the extra info wth the value selected by the user
+      // so that we show only the extra info wth the value selected by the user
       const intervals = this.lodash.filter(values, (v) => {
         return v[2] === value
       })

--- a/src/fragments/forms/map-form/components/place-and-directions/components/route-details/route-details.js
+++ b/src/fragments/forms/map-form/components/place-and-directions/components/route-details/route-details.js
@@ -24,7 +24,7 @@ export default {
   watch: {
     /**
      * Every time the response data changes
-     * the map builder is reseted and the
+     * the map builder is reset and the
      * map data is reloaded
      */
     mapViewData: {
@@ -55,8 +55,8 @@ export default {
       }
     },
     /**
-     * Builds and return the routes 
-     * parsed, with translations and 
+     * Builds and return the routes
+     * parsed, with translations and
      * humanized content
      * @returns {Array} of route objects
      */
@@ -86,10 +86,10 @@ export default {
       return value
     },
     /**
-     * Get the route summary with humanized 
+     * Get the route summary with humanized
      * distance and duration data
-     * @param {*} summary 
-     * @param {*} unit 
+     * @param {*} summary
+     * @param {*} unit
      * @return {Object} summary
      */
     getHumanizedSummary (summary, unit = null) {
@@ -108,7 +108,7 @@ export default {
     /**
      * get the parsed segments by
      * humanizing the duration and distances
-     * @param {*} segments 
+     * @param {*} segments
      * @returns {Object} segments
      */
     parseSegments (segments) {
@@ -131,7 +131,7 @@ export default {
      * Handle the active route index change
      * by emitting a changeActiveRouteIndex
      * event via eventBus
-     * @param {*} index 
+     * @param {*} index
      * @emits changeActiveRouteIndex
      */
     changeActiveRouteIndex (index) {
@@ -142,8 +142,8 @@ export default {
      * prepare the data and emit
      * and event targeting the highlight
      * of this segment
-     * @param {*} segment 
-     * @param {*} index 
+     * @param {*} segment
+     * @param {*} index
      * @emits highlightPolylineSections
      */
     segmentClicked (segment, index) {
@@ -155,8 +155,8 @@ export default {
     },
     /**
      * Build the the extra info highlighting data
-     * @param {*} segment 
-     * @param {*} index 
+     * @param {*} segment
+     * @param {*} index
      * @returns {Object}
      */
     buildExtraHighlighPolylineData (segment, index) {

--- a/src/fragments/forms/map-form/components/place-and-directions/places-and-directions.js
+++ b/src/fragments/forms/map-form/components/place-and-directions/places-and-directions.js
@@ -97,7 +97,7 @@ export default {
     },
 
     /**
-     * Determines if the inputs support diretions mode
+     * Determines if the inputs support directions mode
      */
     inputsupportsDirections () {
       let supports = this.$store.getters.mode === constants.modes.place || this.$store.getters.mode === constants.modes.directions
@@ -126,7 +126,7 @@ export default {
      * Every time the appRouteData changes
      * and it has at least one place defined
      * the map data is reloaded, so we keep the
-     * the map serach and synchronized with the url
+     * the map search and synchronized with the url
      */
     reloadAfterAppRouteDataChanged (appRouteData) {
       if (appRouteData && appRouteData.places.length > 0) {
@@ -156,12 +156,12 @@ export default {
 
     /**
      * Set the place focus index
-     * @param {*} index 
+     * @param {*} index
      */
     setfocusedPlaceInput(index) {
       this.placeFocusIndex = index
       setTimeout(() => {
-        this.$forceUpdate()        
+        this.$forceUpdate()
       }, 200)
     },
 
@@ -183,7 +183,7 @@ export default {
       this.eventBus.$on('switchToDirections', () => {
         if (context.places.length === 1) {
           context.addPlaceInput()
-        } 
+        }
         if (context.places[0].isEmpty()) {
           context.setfocusedPlaceInput(0)
         } else {
@@ -221,16 +221,16 @@ export default {
       this.eventBus.$on('filtersChangedExternally', () => {
         // get the info if all the inputs are filled
         let allPlacesAreFilled = this.getFilledPlaces().length === this.places.length
-        
+
         // Filters are only used to calculate route (directions or round trip)
-        // so we must update the app route if we are already 
-        // in directions/round trip mode if all the place inputs are filled 
-        // and. If the app is, for example in place mode 
+        // so we must update the app route if we are already
+        // in directions/round trip mode if all the place inputs are filled
+        // and. If the app is, for example in place mode
         // there is nothing to be done
         let readyToDirections = (context.$store.getters.mode === constants.modes.directions && allPlacesAreFilled)
         let hasRoundTripInAppRoute = lodash.get(context, '$store.getters.appRouteData.options.options.round_trip')
         let readyToRoundTrip = (context.$store.getters.mode === constants.modes.roundTrip && hasRoundTripInAppRoute)
-        
+
         if (context.active && (readyToDirections || readyToRoundTrip)) {
           context.updateAppRoute()
         }
@@ -275,7 +275,7 @@ export default {
       })
 
       // If the app is in a low resolution mode
-      // hidde the sidebar when route sections are highlighted
+      // hide the sidebar when route sections are highlighted
       this.eventBus.$on('highlightPolylineSections', () => {
         const sidebarVisible = !context.$lowResolution
         context.setSidebarIsOpen(sidebarVisible)
@@ -325,7 +325,7 @@ export default {
     directionsFromPoint (data) {
       // If there is already a place selected and
       // directions from a selected point is triggered
-      // then we consider that the existing point is 
+      // then we consider that the existing point is
       // the destination, and then goes to position 1
       let filledPlaces = this.getFilledPlaces()
       if (filledPlaces.length === 1) {
@@ -385,8 +385,8 @@ export default {
      * @param {*} data
      */
     directionsToPoint (data) {
-      const toPlace = data.place || new Place(data.latlng.lng, data.latlng.lat, '', { resolve: true })  
-      let filledPlaces = this.getFilledPlaces().length     
+      const toPlace = data.place || new Place(data.latlng.lng, data.latlng.lat, '', { resolve: true })
+      let filledPlaces = this.getFilledPlaces().length
       const placeIndex = filledPlaces === 0 ? 0 : 1
       this.places[placeIndex] = toPlace
 
@@ -408,8 +408,8 @@ export default {
         setTimeout(() => {
           if (context.places.length === 1) {
             context.addPlaceInput()
-            
-            // After addging a place input it
+
+            // After adding a place input it
             // is necessary to wait a bit
             // before reordering the places
             setTimeout(() => {
@@ -449,7 +449,7 @@ export default {
      * @param {*} data {latlng: ..., place:...}
      */
     addRouteStop (data) {
-      // Only one placeinput, so the selected point will be the 'from'
+      // Only one place input, so the selected point will be the 'from'
       if (this.places.length === 1) {
         this.directionsFromPoint(data)
       } else {
@@ -463,9 +463,9 @@ export default {
         // be decreased so that the stops happen before the destination
         if (closestPlaceIndex === this.places.length - 1 && !convertStopAfterRouteEndingToDestination) {
           closestPlaceIndex--
-        } 
+        }
         // In the other cases, we have to 'inject' a route point between the exiting points
-        // To do that we add a place input, setits coordinates and then
+        // To do that we add a place input, set its coordinates and then
         // we change the app url so that the route will be recalculated
         const injectedIndex = this.injectPlaceAndReturnIndex(data.latlng, closestPlaceIndex)
         const context = this
@@ -475,7 +475,7 @@ export default {
         }).catch((err) => {
           console.log(err)
           context.showError(this.$t('placesAndDirections.notPossibleToCalculateRoute'), { timeout: 0 })
-        })        
+        })
       }
     },
 
@@ -541,7 +541,7 @@ export default {
      * Update map data by setting the view mode, and calculating the directions or seeing a sigle place state
      */
     updateMapData () {
-      // This method does not deal with search mode, becouse when in search mode
+      // This method does not deal with search mode, because when in search mode
       // th SimplePlaceSearch component will catch this case and list the results
       if (this.$store.getters.mode !== constants.modes.search) {
         const isRoundTrip = this.$store.getters.mode === constants.modes.roundTrip
@@ -626,7 +626,7 @@ export default {
                 context.eventBus.$emit('mapViewDataChanged', mapViewData)
                 context.setSidebarIsOpen()
                 resolve(mapViewData)
-              })             
+              })
             }
           }).catch(result => {
             context.handleCalculateDirectionsError(result)
@@ -768,7 +768,7 @@ export default {
       // updateAppRoute will switch to place
       // mode. To keep two place inputs
       // in order to allow the user to continue to
-      // use the directions mode, readd a place input
+      // use the directions mode, add a place input
       if (keepDirectionsMode && placeInputsBeforeRemoval === 2) {
         this.eventBus.$emit('newInfoAvailable', false)
         setTimeout(() => {
@@ -863,7 +863,7 @@ export default {
      * When the direct property of a place changes
      * updates the app route so that a new route is
      * calculated
-     * @param {*} data 
+     * @param {*} data
      */
     changedDirectPlace (data) {
       this.places[data.index].direct = data.place.direct
@@ -947,7 +947,7 @@ export default {
 
     /**
      * Determines if a place input at a given index must be focused
-     * @param {*} index 
+     * @param {*} index
      * @returns {Boolean}
      */
     autofocusEnabled (index) {

--- a/src/fragments/forms/place-input/place-input.js
+++ b/src/fragments/forms/place-input/place-input.js
@@ -107,7 +107,7 @@ export default {
      */
     hasAutomaticFocus () {
       // If is a mobile device, do not use automatic
-      // focus to avoid openning the keyboard
+      // focus to avoid opening the keyboard
       if (this.isMobile) {
         return false
       }
@@ -176,7 +176,7 @@ export default {
     },
 
     /**
-     * Defines the input colums factor based on the current resolution
+     * Defines the input columns factor based on the current resolution
      * @returns {Integer}
      */
     inputColumnFactor () {
@@ -244,7 +244,7 @@ export default {
     },
 
     /**
-     * Determines if the delete button is availabel for the current place input
+     * Determines if the delete button is available for the current place input
      */
     deleteAvailable () {
       return this.index !== 0
@@ -265,13 +265,13 @@ export default {
       return available
     },
     /**
-     * Determines if the place input floating menu button is availabel for the current place input
+     * Determines if the place input floating menu button is available for the current place input
      */
     placeMenuAvailable () {
       return this.$lowResolution && !this.single && (this.index > 0 || this.directIsAvailable || this.switchCoordsAvailable)
     },
     /**
-     * Determines if the place input directions menu button is availabel for the current place input
+     * Determines if the place input directions menu button is available for the current place input
      */
     directionsAvailable () {
       if (!this.supportDirections || !appConfig.supportsDirections) {
@@ -361,7 +361,7 @@ export default {
     },
     /**
      * Set the pick place input source
-     * @uses index 
+     * @uses index
      * @uses predictableIda
      */
     setPickPlaceSource () {
@@ -375,7 +375,7 @@ export default {
      */
     emptyPickPlaceSource () {
       this.$store.commit('pickPlaceIndex', null)
-      this.$store.commit('pickPlaceId', null)   
+      this.$store.commit('pickPlaceId', null)
     },
     /**
      * Run search if in search mode or resolve place if model is unresolved
@@ -495,7 +495,7 @@ export default {
         const isPasteEvent = event instanceof ClipboardEvent
         // In case of a ClipboardEvent (ctr + v)
         // we must just ignore, since the input
-        // model  has not changed yet and it will 
+        // model  has not changed yet and it will
         // trigger another change event when it changes
         if (!isPasteEvent) {
           event.preventDefault()
@@ -523,14 +523,14 @@ export default {
      * suggetions for the other cases
      */
     handleSearchInputEnter () {
-      // We can only try yo auto select the first result 
+      // We can only try yo auto select the first result
       // if the inputted text is not a coordinate
       if (!this.localModel.nameIsCoord()) {
         let context = this
         if (appConfig.autoSelectFirstExactAddressMatchOnSearchEnter) {
           this.eventBus.$emit('showLoading', true)
           PlacesSearch(this.localModel.placeName, 10).then(places => {
-            // If the first result is an address and the match_type is exact, 
+            // If the first result is an address and the match_type is exact,
             // then we auto select the first item on the enter/return action
             const addresses = this.lodash.filter(places, (p) => {
               return (p.properties.layer === 'address' || p.properties.layer === 'postalcode') && p.properties.match_type === 'exact'
@@ -629,7 +629,7 @@ export default {
     selected () {
       this.focused = false
       let data =  { index: this.index, place: this.model, single: this.single }
-      
+
       let expectedPromise = this.$root.appHooks.run('placeSelected', data)
       let context = this
       // If a promise is returned
@@ -641,7 +641,7 @@ export default {
         })
       } else { // if nothing was returned, just proceed
         context.$emit('selected', data)
-      }      
+      }
       this.$forceUpdate()
     },
 
@@ -655,7 +655,7 @@ export default {
     },
 
     /**
-     * Deal with the remove a place input click 
+     * Deal with the remove a place input click
      * by hidden the floating menu (if visible)
      * and by emitting the corresponding event
      */
@@ -665,7 +665,7 @@ export default {
     },
 
     /**
-     * Deal with the start directions button click 
+     * Deal with the start directions button click
      * by emitting the corresponsing event
      */
     startDirections () {
@@ -685,10 +685,10 @@ export default {
     },
     /**
      * Set the current input as having the focus
-     * @param {*} data can be a boolean value or an Event. 
+     * @param {*} data can be a boolean value or an Event.
      * If it is the second case, we consider it as false
      */
-    setFocus (data) {      
+    setFocus (data) {
       // When the user clicks outside an input
       // this method is called and is intended to
       // set the focus as false in rhis case.
@@ -697,13 +697,13 @@ export default {
       // is expected to be MouseEvent object and no a boolean.
       if (typeof data === 'object' && data.clickedOutside) {
         if (this.inputWasActiveAndLostFocus(data)) {
-          this.emptyPickPlaceSource()          
+          this.emptyPickPlaceSource()
           this.focused = false
         }
       } else {
         this.focused = data // data is boolean in this case
-        // If the input is focused, set the pick place source 
-        this.setPickPlaceSource()  
+        // If the input is focused, set the pick place source
+        this.setPickPlaceSource()
       }
       // Once the focused was set to true based on a user
       // interaction event then it is not anymore in automatic mode

--- a/src/fragments/forms/profile-selector/profile-selector.js
+++ b/src/fragments/forms/profile-selector/profile-selector.js
@@ -94,24 +94,24 @@ export default {
         this.activeProfileSlug = profileSlug
         this.activeVehicleType = vehicleTypeSlug
 
-        // Update the values in map filtes object
-        OrsFilterUtil.setFilterValue(constants.profileFilterName, profileSlug) 
-        OrsFilterUtil.setFilterValue(constants.vehicleTypeFilterName, vehicleTypeSlug)  
+        // Update the values in map filters object
+        OrsFilterUtil.setFilterValue(constants.profileFilterName, profileSlug)
+        OrsFilterUtil.setFilterValue(constants.vehicleTypeFilterName, vehicleTypeSlug)
 
         // Store the selected profile as default profile
         // so the next time the ap is loaded, it will be selected by default
         let mapSettings = this.$store.getters.mapSettings
         mapSettings.defaultProfile = profileSlug
         mapSettings.defaultVehicleType = vehicleTypeSlug
-        
+
         this.$store.dispatch('saveSettings', mapSettings).then(() => {
-          let context = this          
+          let context = this
           setTimeout(() => {
             context.extraProfilesOpen = false
             resolve(profileSlug)
           }, 200)
         })
-      })        
+      })
     },
     /**
      * Change the value of local profile and vehicle type
@@ -126,7 +126,7 @@ export default {
 
       if (this.activeProfileSlug !== profile || this.activeVehicleType !== vehicleType) {
         this.setProfile(profile, vehicleType)
-      }      
+      }
     }
   }
 }

--- a/src/fragments/forms/simple-place-search/simple-place-search.js
+++ b/src/fragments/forms/simple-place-search/simple-place-search.js
@@ -52,7 +52,7 @@ export default {
     },
     showNewInfo () {
       return this.newInfoAvailable
-    }, 
+    },
     showRouteDetailsTooltip () {
       return this.showNewInfo && !this.$store.getters.isSidebarVisible
     }
@@ -78,7 +78,7 @@ export default {
      * Every time the appRouteData changes
      * and it has at least one place defined
      * the map data is reloaded, so we keep the
-     * the map serach and synchronized with the url
+     * the map search and synchronized with the url
      */
     reloadAfterAppRouteDataChanged (appRouteData) {
       if (appRouteData && appRouteData.places.length > 0) {
@@ -114,9 +114,9 @@ export default {
       })
 
       // When there are changes in the route and and the
-      // side bar is not opend, notify visually that there
+      // side bar is not opened, notify visually that there
       // new data about the route calculated that can be seen
-      // by openning the sidebar
+      // by opening the sidebar
       this.eventBus.$on('newInfoAvailable', (available) => {
         if (!context.$store.getters.leftSideBarOpen) {
           context.newInfoAvailable = available
@@ -147,7 +147,7 @@ export default {
       const appMode = new AppMode(this.$store.getters.mode)
       const newRoute = appMode.getRoute([this.place])
 
-      // Only navigate to a new route if params has changed     
+      // Only navigate to a new route if params has changed
       const zoomChanged =  Number(newRoute.params.zoom) !== Number(this.$route.params.zoom)
       const centerChanged = newRoute.params.center !== this.$route.params.center
       const termchanged = newRoute.params.term !== this.$route.params.term
@@ -172,14 +172,14 @@ export default {
           let mapSettings = this.$store.getters.mapSettings
           mapSettings.mapCenter = this.$store.getters.appRouteData.options.center
           this.$store.dispatch('saveSettings', mapSettings).then(() => {
-            this.search()    
-            this.$forceUpdate()        
-          })          
+            this.search()
+            this.$forceUpdate()
+          })
         }
       } else {
         this.$forceUpdate()
       }
-      
+
     },
     /**
      * When the menu btn is clicked, open the main
@@ -209,7 +209,7 @@ export default {
       } else {
         if (this.place.isEmpty()) { // place has no lat and lng
           // Make sure that the place will
-          // not be resolved using its name 
+          // not be resolved using its name
           // if it is empty when switching to directions
           // It must be resolved using its coordinates
           this.place.placeName = ''
@@ -252,7 +252,7 @@ export default {
 
     /**
      * Set a a suggested place as the selected one for a given place input
-     * @param {*} data - can be the palce object or an object containing the place
+     * @param {*} data - can be the place object or an object containing the place
      */
     selectPlace (data) {
       if (data.place) {

--- a/src/fragments/map-view/MapView.vue
+++ b/src/fragments/map-view/MapView.vue
@@ -19,22 +19,22 @@
 
       <l-control-polyline-measure v-if="showControls && distanceMeasureToolAvailable" :options="polylineMeasureOptions"/>
 
-      <!-- draw tool bar is added programatically via map-view.js setAvoidPolygonDrawingTool method -->
+      <!-- draw tool bar is added programmatically via map-view.js setAvoidPolygonDrawingTool method -->
       <!-- <l-draw-toolbar :options="drawingOptions" position="topright"/> -->
 
-      <map-view-markers :mode="mode" :markers="markers"          
+      <map-view-markers :mode="mode" :markers="markers"
         @markerMoved="markerMoved"
         @markerClicked="markerClicked"
         @removePlace="removePlace"
         @markAsDirectfromHere="markAsDirectfromHere">
-      </map-view-markers> 
+      </map-view-markers>
 
-       <map-view-markers 
-        :mode="mode" 
-        :markers="pois" 
+       <map-view-markers
+        :mode="mode"
+        :markers="pois"
         is-poi
         @markerClicked="markerClicked">
-      </map-view-markers> 
+      </map-view-markers>
 
       <!--render isochrones polygons -->
       <template v-if="polygons">
@@ -70,17 +70,17 @@
       <template  v-for="alternativeRoute in alternativeRoutes">
         <ors-l-polyline :key="alternativeRoute.index" not-active
           :color="alternativeRouteColor"
-          @click="alternativeRouteIndexSelected(alternativeRoute.index, $event)"            
+          @click="alternativeRouteIndexSelected(alternativeRoute.index, $event)"
           :lat-lngs="alternativeRoute.polyline" >
         </ors-l-polyline>
       </template>
        <template v-if="showActivRouteData">
         <ors-l-polyline :draggable="isPolylineDraggable"
-          @followPolyline="followPolyline" 
+          @followPolyline="followPolyline"
           @rightClicked="mapRightClick"
           :focused-poly-index="highlightedRoutePointIndex"
-          @addStopViaPolylineDrag="addStopViaPolylineDrag" 
-          :route="activeRouteData" 
+          @addStopViaPolylineDrag="addStopViaPolylineDrag"
+          :route="activeRouteData"
           :tooltip-icon="routingProfileIcon">
         </ors-l-polyline>
       </template>
@@ -103,18 +103,18 @@
           :attribution="overlayerTileProvider.attribution"
           :token="overlayerTileProvider.token"
           layer-type="overlay"/>
-      <v-btn fab small @click.stop="toggleAcessibleMode" v-if="accessbilityToolAvailable"
-        :title="$t('maps.toggleAcessibleMode')" 
+      <v-btn fab small @click.stop="toggleAcessibleMode" v-if="accessibilityToolAvailable"
+        :title="$t('maps.toggleAcessibleMode')"
         :class="{'extra-low-resolution': $xlResolution}"
-        class="do-not-trigger-close-bottom-nav accessibility-btn" > 
+        class="do-not-trigger-close-bottom-nav accessibility-btn" >
         <v-icon large :color="$store.getters.mapSettings.acessibleModeActive? 'primary': 'default'" >accessibility</v-icon>
       </v-btn>
-      <v-btn fab small v-if="canFitFeatures && showControls" 
+      <v-btn fab small v-if="canFitFeatures && showControls"
         class="fit-all-features"
         :title="$t('mapView.fitAllFeatures')"
-        :class="{'extra-low-resolution': $xlResolution}" 
-        @click.stop="fitAllFeatures()" > 
-        <v-icon large >all_out</v-icon> 
+        :class="{'extra-low-resolution': $xlResolution}"
+        @click.stop="fitAllFeatures()" >
+        <v-icon large >all_out</v-icon>
       </v-btn>
 
       <!-- highlight extra info polyline -->
@@ -123,7 +123,7 @@
       <my-location v-if="supportsMyLocationBtn" class="my-location-btn" :active="myLocationActive" @updateLocation="updateMyLocation"></my-location>
       <img class="over-brand" v-if="showBrand" src="@/assets/img/heigit-and-hd-uni.png" :alt="$t('global.brand')" :title="$t('global.brand')">
 
-      <!-- the container below might be used to to programatically add controls/components -->
+      <!-- the container below might be used to to programmatically add controls/components -->
       <div ref="customMapControlsContainer" style="z-index: 501" class="custom-controls" ></div>
     </l-map>
     <v-btn v-if="$store.getters.embed" small :title="$t('mapView.viewOnORS')" class="view-on-ors" target="_blank" :href="nonEmbedUrl" > {{$t('mapView.viewOnORS')}} <v-icon right small >open_in_new</v-icon> </v-btn>
@@ -134,7 +134,7 @@
       <v-btn fab small @click="moveMapCenter('left')" :title="$t('mapView.moveMapPositionToLeft')" class="move-map-arrow left do-not-trigger-close-bottom-nav" > <v-icon large color="primary" >arrow_back</v-icon> </v-btn>
       <v-btn fab small @click="moveMapCenter('up')" :title="$t('mapView.moveMapPositionToUp')" class="move-map-arrow up do-not-trigger-close-bottom-nav" > <v-icon large color="primary" >arrow_upward</v-icon> </v-btn>
       <v-btn fab small @click="moveMapCenter('right')" :title="$t('mapView.moveMapPositionToRight')" class="move-map-arrow right do-not-trigger-close-bottom-nav" > <v-icon large color="primary" >arrow_forward</v-icon> </v-btn>
-      <v-btn fab small @click="moveMapCenter('down')" :title="$t('mapView.moveMapPositionToDown')" class="move-map-arrow down do-not-trigger-close-bottom-nav" :style="{top: acessibilityBtnTopPosition}" > <v-icon large color="primary" >arrow_downward</v-icon> </v-btn>      
+      <v-btn fab small @click="moveMapCenter('down')" :title="$t('mapView.moveMapPositionToDown')" class="move-map-arrow down do-not-trigger-close-bottom-nav" :style="{top: acessibilityBtnTopPosition}" > <v-icon large color="primary" >arrow_downward</v-icon> </v-btn>
     </div>
   </div>
 </template>

--- a/src/fragments/map-view/components/map-left-click/map-left-click.js
+++ b/src/fragments/map-view/components/map-left-click/map-left-click.js
@@ -4,7 +4,7 @@
  * @emits showLoading [via eventBus] (when resolving place info)
  * @emits directionsToPoint
  * @listens mapRightClicked
- * @listens mapLeftClicked (to close the righ click pop up)
+ * @listens mapLeftClicked (to close the right click pop up)
  */
 import GeoUtils from '@/support/geo-utils'
 import { ReverseGeocode } from '@/support/ors-api-runner'
@@ -152,9 +152,9 @@ export default {
       return result
     },
     /**
-     * Build a place and emits an event to set the 
+     * Build a place and emits an event to set the
      * app in directions mode to the clicked place
-     * @param {*} placeInfo 
+     * @param {*} placeInfo
      * @emits directionsToPoint
      */
     directionstoPoint (placeInfo) {

--- a/src/fragments/map-view/components/map-right-click/map-right-click.js
+++ b/src/fragments/map-view/components/map-right-click/map-right-click.js
@@ -8,7 +8,7 @@ import lodash from 'lodash'
  * @emits closed
  * @emits rightClickEvent
  * @listens mapRightClicked
- * @listens mapLeftClicked (to close the righ click pop up)
+ * @listens mapLeftClicked (to close the right click pop up)
  */
 export default {
   data () {
@@ -63,7 +63,7 @@ export default {
       window.open(url, '_blank')
     },
     /**
-     * Deal with close event by hidding the right click pop up
+     * Deal with close event by hiding the right click pop up
      * and by emitting close event
      * @emits closed
      */
@@ -84,7 +84,7 @@ export default {
       this.clickLatlng = null
     },
     /**
-     * Deal wth the map rigt click, preparing the data and displaying the modal
+     * Deal wth the map right click, preparing the data and displaying the modal
      * @param {*} data
      */
     mapRightClick (data) {

--- a/src/fragments/map-view/components/map-view-markers/map-view-markers.js
+++ b/src/fragments/map-view/components/map-view-markers/map-view-markers.js
@@ -44,7 +44,7 @@ export default {
      */
     markersClusterOptions () {
       let options = {}
-      // If the options objext is modified in the hook, the changes
+      // If the options object is modified in the hook, the changes
       // will reflect here and the returned object will incorporate the changes
       this.$root.appHooks.run('beforeUseMarkerClusterOptions', options)
       return options
@@ -75,7 +75,7 @@ export default {
       const isDraggable = draggableModes.includes(this.mode)
       return isDraggable
     },
-    
+
      /**
      * Show the marker popup
      */

--- a/src/fragments/map-view/components/ors-l-polyline/ors-extended-polyline.js
+++ b/src/fragments/map-view/components/ors-l-polyline/ors-extended-polyline.js
@@ -3,7 +3,7 @@ import GeoUtils from '@/support/geo-utils'
 import orsDictionary from '@/resources/ors-dictionary'
 import lodash from 'lodash'
 
-// The import below will add some methods to Leaflet.GeometryUtil 
+// The import below will add some methods to Leaflet.GeometryUtil
 // Even if it is not been accessed within this class, it is being used!
 import 'leaflet-geometryutil'
 
@@ -12,7 +12,7 @@ import 'leaflet-geometryutil'
  * to create an stop point.
  * @emits followMarkerClicked - when the marker created over the polyline to show current cursor position is clicked
  * @emits follow - when a point of the polyline is focused with the mouse
- * @emits addstop - when the user drag the new polyline vertice into a location
+ * @emits addstop - when the user drag the new polyline vertex into a location
  */
 class OrsExtendedPolyline {
   constructor (context, showPointInfo = false) {
@@ -20,12 +20,12 @@ class OrsExtendedPolyline {
     const options = {
       options: {
         distance: 20,   //distance from pointer to the polyline
-        tollerance: 5,  //tollerance for snap effect to vertex
+        tollerance: 5,  //tolerance for snap effect to vertex
         vertices: {
           //first: true,  //first vertex is draggable
-          //middle: true, //middle vertices are draggables
+          //middle: true, //middle vertices are draggable
           //last: true,   //last vertex draggable
-          //insert: true, //define if the number of polyline's vertices can change
+          //insert: true, //define if the number of polyline vertices can change
         },
         icon: new Leaflet.DivIcon({
           iconSize: new Leaflet.Point(8, 8),
@@ -34,29 +34,29 @@ class OrsExtendedPolyline {
       },
       tempPolylineDraggingMarkerRef: null,
       tempPolylineDraggingMarkerInfoRef: null,
-      
-      initialize: this.initialize,    
-      addHooks: this.addHooks,    
+
+      initialize: this.initialize,
+      addHooks: this.addHooks,
       removeHooks: this.removeHooks,
-      
+
       _showPointInfo: this.showPointInfo,
-      _processDrag: this.processDrag,    
-      _getClosestPointAndSegment: this.getClosestPointAndSegment,    
-      _mouseContextClick: this.mouseContextClick,    
-      _mouseMove: this.mouseMove,    
+      _processDrag: this.processDrag,
+      _getClosestPointAndSegment: this.getClosestPointAndSegment,
+      _mouseContextClick: this.mouseContextClick,
+      _mouseMove: this.mouseMove,
       _getClosestIndex: this.getClosestIndex,
       _getInjectAfterIndex: this.getInjectAfterIndex,
-      _isInvalidDrag: this.isInvalidDrag,    
-      _markerDragStart: this.markerDragStart,    
-      _markerDrag: this.markerDrag,    
+      _isInvalidDrag: this.isInvalidDrag,
+      _markerDragStart: this.markerDragStart,
+      _markerDrag: this.markerDrag,
       _markerDragEnd: this.markerDragEnd,
       _buildInfoIcon: this.buildInfoIcon,
       _createOrUpdateCustomMarkers: this.createOrUpdateCustomMarkers,
       _polylineClicked: this.showCustomMarkers,
       _updateCustomMarkers: this.updateCustomMarkers,
       _createCustomMarkers: this.createCustomMarkers,
-      
-      // The `this`context inside the methods above 
+
+      // The `this`context inside the methods above
       // refers to the leaflet component context.
       // so to have access to the external world
       // we have to bind the context passed via
@@ -64,11 +64,11 @@ class OrsExtendedPolyline {
       // it via method
       _getOuterContext: this.getContext.bind(context)
     }
-    this.addPolylineCustomBehaviour(options)    
+    this.addPolylineCustomBehaviour(options)
   }
 
   /**
-   * Get the vuejs component context provided via constructor
+   * Get the Vue component context provided via constructor
    * @returns {Object} Vue instance
    */
   getContext () {
@@ -79,28 +79,28 @@ class OrsExtendedPolyline {
    * Extends the polyline by adding the editingDrag
    */
   addPolylineCustomBehaviour (options) {
-    Leaflet.EditDrag = Leaflet.EditDrag || {};    
-    Leaflet.EditDrag.Polyline = Leaflet.Handler.extend(options);    
-    
+    Leaflet.EditDrag = Leaflet.EditDrag || {};
+    Leaflet.EditDrag.Polyline = Leaflet.Handler.extend(options);
+
     Leaflet.Polyline.addInitHook(function() {
       if (this.edit_with_drag) {
         return
       }
-    
+
       if (Leaflet.EditDrag.Polyline) {
         this.editingDrag = new Leaflet.EditDrag.Polyline(this);
-    
+
         if (this.options.edit_with_drag) {
           this.editingDrag.enable()
         }
       }
-    
+
       this.on('add', function () {
         if (this.editingDrag && this.editingDrag.enabled()) {
           this.editingDrag.addHooks()
         }
       })
-    
+
       this.on('remove', function () {
         if (this.editingDrag && this.editingDrag.enabled()) {
           this.editingDrag.removeHooks()
@@ -116,7 +116,7 @@ class OrsExtendedPolyline {
   /**
    * Initialize the draggable polyline
    * by setting references to objects and options
-   * @param {*} poly 
+   * @param {*} poly
    */
   initialize (poly) {
     this._poly = poly
@@ -164,7 +164,7 @@ class OrsExtendedPolyline {
 
   /**
    * When a click is done ends the dragging event
-   * @param {Event} event 
+   * @param {Event} event
    */
   mouseContextClick (event) {
     var closest = Leaflet.GeometryUtil.closest(this._map, this._poly, event.latlng, true)
@@ -178,7 +178,7 @@ class OrsExtendedPolyline {
       if (index > -1) {
         this._poly.spliceLatLngs(index, 1)
         this._map.removeLayer(this._marker)
-        this._map.removeLayer(this._markerInfo)    
+        this._map.removeLayer(this._markerInfo)
         this._marker = null
         this._markerInfo = null
       }
@@ -197,7 +197,7 @@ class OrsExtendedPolyline {
 
   /**
    * Show custom markers that appears over the polyline
-   * @param {*} event 
+   * @param {*} event
    */
   showCustomMarkers (event) {
     if (this.options.edit_with_drag) {
@@ -213,12 +213,12 @@ class OrsExtendedPolyline {
   }
 
   /**
-   * Create or update the custom markers 
+   * Create or update the custom markers
    * when the mouse move over the map.
    * If the mouse is over the polyline
    * creates a marker that follows the polyline
    * and can be used to create the drag effect
-   * @param {*} e 
+   * @param {*} e
    */
   createOrUpdateCustomMarkers (e) {
     if (this._dragging) return
@@ -241,7 +241,7 @@ class OrsExtendedPolyline {
       }
       if (this._markerInfo) {
         this._map.removeLayer(this._markerInfo)
-      }    
+      }
       this._marker = null
       this._markerInfo = null
     }
@@ -249,7 +249,7 @@ class OrsExtendedPolyline {
 
   /**
    * Update custom markers when the mouse moves over the polyline
-   * @param {*} closest 
+   * @param {*} closest
    */
   updateCustomMarkers (closest) {
     this.tempPolylineDraggingMarkerRef = this._marker.addTo(this._map)
@@ -268,7 +268,7 @@ class OrsExtendedPolyline {
   }
   /**
    * Create custom markers when the mouse is over the polyline
-   * @param {*} closest 
+   * @param {*} closest
    */
   createCustomMarkers (closest) {
     this.closest = closest
@@ -283,7 +283,7 @@ class OrsExtendedPolyline {
     })
 
     let closestIndex = this._getClosestIndex()
-    
+
     // The hover polyline route info pop up is disabled for now
     if (this._showPointInfo) {
       const infoIcon = this._buildInfoIcon(closestIndex)
@@ -303,7 +303,7 @@ class OrsExtendedPolyline {
     if (coordinates && coordinatePolylineIndex !== null) {
       const route = context.route
       const altitude = coordinates[coordinatePolylineIndex][2].toFixed(2)
-      
+
       // calculate the distance of the point
       const totaldistance = route.summary.distance.toFixed(1)
       const currentStep = (route.geometry.coordinates.length / (coordinatePolylineIndex + 1))
@@ -312,7 +312,7 @@ class OrsExtendedPolyline {
       const orsPolylineTranslations = context.$t('orsLPolyline')
       const orsDictionaryTranslations = context.$t('orsDictionary')
       var surfaceType = null
-      
+
       // Get the surface type for the given point
       if (route.properties.extras.surface) {
         for (let key in route.properties.extras.surface.values) {
@@ -327,12 +327,12 @@ class OrsExtendedPolyline {
           surfaceType = translations.unknownSurfaceType
         }
       }
-  
+
       const infoIcon = Leaflet.divIcon({
         className: 'ors-l-polyline-custom-div-icon',
-        html: 
+        html:
         `<div class='ors-l-polyline-info-wrapper'>
-          <div class='ors-l-polyline-vertical-bar'></div>          
+          <div class='ors-l-polyline-vertical-bar'></div>
           <div class='ors-l-polyline-content-block'>
             <div class='ors-l-polyline-top-block-info'>
               <b>${globalTranslations.distance}</b>: ${currentDistance} / ${totaldistance} ${route.summary.unit}<br/>
@@ -351,7 +351,7 @@ class OrsExtendedPolyline {
 
   /**
    * Check whether the drag is valid
-   * @param {*} index 
+   * @param {*} index
    * @returns {Boolean}
    */
   isInvalidDrag (index) {
@@ -374,10 +374,10 @@ class OrsExtendedPolyline {
 
   /**
    * When the marker drag starts
-   * set the closest property and 
-   * set the flag _draggging as true
+   * set the closest property and
+   * set the flag _dragging as true
    * and process the drag
-   * @param {*} event 
+   * @param {*} event
    */
   markerDragStart (event) {
     var latlng = event.target.getLatLng()
@@ -385,13 +385,13 @@ class OrsExtendedPolyline {
     this.closest = Leaflet.GeometryUtil.closest(this._map, this._poly, latlng, true)
     this.startingDragPoint = latlng
     this._dragging = true
-    
-    // Check the tollerance
+
+    // Check the tolerance
     if (this.closest.distance < this.options.tollerance) {
-      this._processDrag()    
+      this._processDrag()
     } else {
       this.closest = this._getClosestPointAndSegment(latlng)
-      this._processDrag() 
+      this._processDrag()
     }
   }
 
@@ -405,11 +405,11 @@ class OrsExtendedPolyline {
     if (this.closest) {
       for (let index = 0; index < this._poly._latlngs.length; index++) {
         let latlng = this._poly._latlngs[index]
-        
+
         if (latlng) {
           let closestLatLng = this.closest.point || this.closest
           closestLatLng = closestLatLng.latlng || closestLatLng
-          
+
           let currentDistance = GeoUtils.calculateDistanceBetweenLocations(latlng, closestLatLng, 'm')
           if (currentDistance === 0) {
             closestIndex = index
@@ -420,7 +420,7 @@ class OrsExtendedPolyline {
               closestIndex = index
             }
           }
-        }            
+        }
       }
     }
     return closestIndex
@@ -446,15 +446,15 @@ class OrsExtendedPolyline {
             injectIndex = index
           }
         }
-      }      
+      }
     }
     return injectIndex
   }
 
   /**
-   * Process the polyline drag by adding a temporary 
+   * Process the polyline drag by adding a temporary
    * vertex to represent user drag action
-   * @param {*} event 
+   * @param {*} event
    */
   processDrag () {
     var closestIndex = this._getClosestIndex()
@@ -483,21 +483,21 @@ class OrsExtendedPolyline {
   }
 
   /**
-   * When the drag event ends, fire the addstop event
-   * set the flat _drgging boolean as false and remove the 
-   * temp marker that follows the curor over the polyline
-   * @param {*} event 
+   * When the drag event ends, fire the addStop event
+   * set the flat _dragging boolean as false and remove the
+   * temp marker that follows the cursor over the polyline
+   * @param {*} event
    */
   markerDragEnd (event) {
     var draggedFromIndex = this._getInjectAfterIndex()
     const data = {event, closest: this.closest, draggedFromIndex}
     this._poly.fireEvent('addstop', data)
     this._dragging = false
-    this._map.removeLayer(this.tempPolylineDraggingMarkerRef) 
+    this._map.removeLayer(this.tempPolylineDraggingMarkerRef)
     if (this.tempPolylineDraggingMarkerInfoRef) {
       this._map.removeLayer(this.tempPolylineDraggingMarkerInfoRef)
-    }  
-    this.startingDragPoint = null   
+    }
+    this.startingDragPoint = null
   }
 }
 

--- a/src/fragments/map-view/components/ors-l-polyline/ors-l-polyline.js
+++ b/src/fragments/map-view/components/ors-l-polyline/ors-l-polyline.js
@@ -10,7 +10,7 @@ export default {
   data () {
     return {
       orsExtendedPolyline: null,
-      backgroundWeight: 11, // will automaticaly be changed based on the weight value on `created`,
+      backgroundWeight: 11, // will automatically be changed based on the weight value on `created`,
       active: true
     }
   },
@@ -105,8 +105,8 @@ export default {
       })
     },
     updatePopup () {
-      if (this.$refs.foregroundPolyline && this.popupContent) {    
-        // Create and show popp
+      if (this.$refs.foregroundPolyline && this.popupContent) {
+        // Create and show popup
         this.$refs.foregroundPolyline.mapObject.bindPopup(this.popupContent, {autoClose: true, closeOnClick: true, autoPan: false}).openPopup()
       }
     },
@@ -114,21 +114,21 @@ export default {
      * When the polyline is clicked
      * check if it is active. If so, show clicked point
      * the polyline details. If not active, just
-     * forward the event by emitting a vuejs `click` event
-     * @param {*} event 
+     * forward the event by emitting a Vue.js `click` event
+     * @param {*} event
      * @emits click
      */
     click (event) {
       if (!this.notActive && this.$refs.foregroundPolyline.mapObject) {
         this.openPopup(event)
-      } else {        
+      } else {
         this.$emit('click', event)
       }
     },
     /**
      * Show the details of a polyline point
      * by firing the polylineClicked event
-     * @param {Event} event 
+     * @param {Event} event
      * @fire polylineClicked
      */
     showPolylinePointDetails (event) {
@@ -141,7 +141,7 @@ export default {
     },
     /**
      * Show the polyline point by index
-     * @param {Number} polylineCoordsIndex 
+     * @param {Number} polylineCoordsIndex
      */
     showPolylinePointByIndex (polylineCoordsIndex) {
       const customEvent = new Event('showPolylinePointByIndex')
@@ -152,7 +152,7 @@ export default {
   },
   computed: {
     /**
-     * Get the latlngs coodinate array
+     * Get the latlngs coordinate array
      * from the latLngs prop or from the route
      * coordinates or return an empty array
      * @returns {Array}
@@ -207,7 +207,7 @@ export default {
       console.error('Latlngs or route object must be passed with valid values')
     } else {
       this.backgroundWeight = this.weight + 4
-    
+
       // If draggable is defined via prop as true
       // then add the necessary attribute on the
       // options object

--- a/src/fragments/map-view/map-definitions.js
+++ b/src/fragments/map-view/map-definitions.js
@@ -97,7 +97,7 @@ const mapDefinitions = {
     const defaultTilesProvider = store.getters.mapSettings.defaultTilesProvider || 'osm'
     var providers = appConfig.mapTileProviders
 
-    // Add custom tile servive if defined in settings
+    // Add custom tile service if defined in settings
     const customTileProviderUrl = store.getters.mapSettings.customTileProviderUrl
     let vueInstance = main.getInstance()
     if (customTileProviderUrl) {
@@ -120,11 +120,11 @@ const mapDefinitions = {
   },
   getOverlayerProviders () {
     let providers = []
-    // Add custom over layer tile servive if defined in settings
+    // Add custom over layer tile service if defined in settings
     const customOverlayerTileProviderUrl = store.getters.mapSettings.customOverlayerTileProviderUrl
     let vueInstance = main.getInstance()
     if (customOverlayerTileProviderUrl) {
-      const overlayerTileService = 
+      const overlayerTileService =
       {
         name: vueInstance.$t('global.customOverlayer'),
         id: 'custom-overlayer',
@@ -132,7 +132,7 @@ const mapDefinitions = {
         attribution: vueInstance.$t('mapView.customTileProvider'),
         url: customOverlayerTileProviderUrl.toString()
       }
-      
+
       providers.push(overlayerTileService)
     }
     return providers

--- a/src/fragments/map-view/map-view.js
+++ b/src/fragments/map-view/map-view.js
@@ -6,9 +6,8 @@
  * Events that this component listens to:
  * @listens redrawAndFitMap [via eventBus] - event that will trigger a map redraw and refit bounds - expects {isMaximized: Boolean, guid: String}
  * @listens clearMap [via eventBus] - event that will trigger a map clear
- * @listens changeActiveRouteIndex [via eventBus] - event that will trigger active rounte index change
- * @listens placeFocusChanged [via eventBus] - updates the map center when a new place is seleted
- *
+ * @listens changeActiveRouteIndex [via eventBus] - event that will trigger active route index change
+ * @listens placeFocusChanged [via eventBus] - updates the map center when a new place is selected *
  * Events emitted via eventBus:
  * @emits activeRouteIndexChanged
  * @emits setSideBarStatus
@@ -148,12 +147,12 @@ export default {
     avoidPolygons: {
       type: Array,
       required: false
-    },    
+    },
   },
   data () {
     return {
       tileProviders: [], // list of tiles provider that will be set via setProviders
-      overlayerTileProviders: [], // list of overlaye tiles provider that will be set via setProviders
+      overlayerTileProviders: [], // list of overlay tiles provider that will be set via setProviders
       layersPosition: 'topright',
       map: null, // map object reference. it will will be defined later
       zoomLevel: null,
@@ -205,15 +204,15 @@ export default {
       return available
     },
     /**
-     * Determines if the accessbility tool is available
+     * Determines if the accessibility tool is available
      * @returns {Boolean}
      */
     accessbilityToolAvailable () {
-      let available = appConfig.accessbilityToolAvailable
+      let available = appConfig.accessibilityToolAvailable
       return available
     },
     /**
-     * Determinses if click on the map to pick a location is active
+     * Determines if click on the map to pick a location is active
      * @returns {Boolean}
      */
     clickToPickActive () {
@@ -222,7 +221,7 @@ export default {
     /**
      * Returns the non embedded mode URL.
      * When in embedded mode, a 'view on ors' btn is displayed and
-     * thhe target url of this btn is the not embedded versios.
+     * the target url of this btn is the not embedded versions
      * @returns {String} url
      */
     nonEmbedUrl () {
@@ -242,7 +241,7 @@ export default {
     /**
      * Determines if the map controls
      * must be shown based on the current
-     * view resolution and the shrinked value
+     * view resolution and the shrink value
      * @returns {Boolean} show
      */
     showControls () {
@@ -275,7 +274,7 @@ export default {
      * Build and return the map center
      * based either on the single visible marker
      * or the current map center defined/set in the store
-     * @returns {Lalng}
+     * @returns {Latlng}
      */
     mapCenter () {
       let latlng = GeoUtils.buildLatLong(this.$store.getters.mapCenter)
@@ -294,10 +293,10 @@ export default {
      * @returns {Boolean}
      */
     showBrand () {
-      return this.mapHeight > 450 || this.$store.getters.embed 
+      return this.mapHeight > 450 || this.$store.getters.embed
     },
     /**
-     * Buil and return the geojson options based on the
+     * Build and return the geojson options based on the
      * color defined as main
      * @returns {Object}
      */
@@ -315,13 +314,13 @@ export default {
       return { style: { color: constants.routeBackgroundColor, weight: '9' } }
     },
     /**
-     * Build and return the ative route data
+     * Build and return the active route data
      * based on the $store.getters.activeRouteIndex
-     * @returns {Array} of latlngs
+     * @returns {Array} of latlng
      */
     activeRouteData () {
       if (this.localMapViewData.hasRoutes()) {
-        // We must not change the orignal object
+        // We must not change the original object
         const toBeTransformedMapViewData = this.localMapViewData.clone()
 
         // get the coordinates of the active route
@@ -329,7 +328,7 @@ export default {
 
         // Vue2-Leaflet, the component used to render data on the map, expect the coordinates in the [lat,lon] order,
         // but the GeoJSON format returned by ORS API contains coordinates in the [lon,lat] order.
-        // So we invert them to provide what the component expectes
+        // So we invert them to provide what the component expects
         route.geometry.coordinates = GeoUtils.switchLatLonIndex(route.geometry.coordinates)
         return route
       }
@@ -342,7 +341,7 @@ export default {
     alternativeRoutes () {
       const alternativeRoutesData = []
       if (this.localMapViewData.hasRoutes()) {
-        // We must not change the orignal object
+        // We must not change the original object
         const toBeTransformedMapViewData = this.localMapViewData.clone()
 
         for (const key in toBeTransformedMapViewData.routes) {
@@ -350,7 +349,7 @@ export default {
           if (index !== this.$store.getters.activeRouteIndex) {
             // Vue2-Leaflet, the component used to render data on the map, expect the coordinates in the [lat,lon] order,
             // but the GeoJSON format returned by ORS API contains coordinates in the [lon,lat] order.
-            // So we invert them to provide what the component expectes
+            // So we invert them to provide what the component expects
             const coords = GeoUtils.switchLatLonIndex(toBeTransformedMapViewData.routes[key].geometry.coordinates)
             const alternativeRoute = { polyline: coords, index: index }
             alternativeRoutesData.push(alternativeRoute)
@@ -362,7 +361,7 @@ export default {
     /**
      * Build and return the polygons to be rendered
      * on the map view based on the polygons
-     * defined in the localmapViewData object.
+     * defined in the localMapViewData object.
      * As the renderer expect the polygons coords in the
      * [lat,lon] order, we switch the coords of each polygon
      * and also set the color and label based on the polygon
@@ -374,18 +373,18 @@ export default {
       if (this.localMapViewData) {
         const translations = this.$t('global.units')
         translations.polygon = this.$t('global.polygon')
-        // We must not change the orignal object
+        // We must not change the original object
         const toBeTransformedMapViewData = this.localMapViewData.clone()
 
         for (const key in toBeTransformedMapViewData.polygons) {
           const polygon = toBeTransformedMapViewData.polygons[key]
           polygon.color = polygon.color || PolygonUtils.buildPolygonColor(key)
-          polygon.fillColor = polygon.fillColor || polygon.color          
+          polygon.fillColor = polygon.fillColor || polygon.color
           polygon.label = polygon.label || PolygonUtils.buildPolygonLabel(polygon, translations)
 
           // Vue2-Leaflet, the component used to render data on the map, expect the coordinates in the [lat,lon] order,
           // but the GeoJSON format returned by ORS API contains coordinates in the [lon,lat] order.
-          // So we invert them to provide what the component expectes
+          // So we invert them to provide what the component expects
           let flattencoords = PolygonUtils.flatCoordinates(polygon.geometry.coordinates)
           polygon.latlngs = GeoUtils.switchLatLonIndex(flattencoords)
           polygons.push(polygon)
@@ -514,9 +513,9 @@ export default {
     mapHeight () {
       return this.height
     },
-    
+
     /**
-     * Determines if the directios mode is active
+     * Determines if the directions mode is active
      */
     isInDirectionsMode () {
       return constants.modes.directions === this.mode
@@ -568,7 +567,7 @@ export default {
       return height
     },
     /**
-     * Returns the optins object for the height graph component
+     * Returns the options object for the height graph component
      * @returns {Object}
      */
     lHeightGraphOptions () {
@@ -576,8 +575,8 @@ export default {
       let activRoute = this.localMapViewData.routes[this.$store.getters.activeRouteIndex]
       let heightGraphTranslations = this.$t('mapView.heightGraph')
 
-      // Build the  mapping for the extra info
-      // that wil be displayd in the graph
+      // Build the mapping for the extra info
+      // that will be displayed in the graph
       // including the translation and the color
       // associated to each extra value
       let extras = lodash.get(activRoute, 'properties.extras')
@@ -606,27 +605,27 @@ export default {
       return options
     },
     /**
-     * Build the map view data for leafletheight graph
-     * As leaflefheight graph does not support alternative routes
+     * Build the map view data for leaflet height graph
+     * As leaflet height graph does not support alternative routes
      * we have to put the active feature (according the active route index)
      * in the first index (0) where the component wil looks for
      * @returns {Object} rawData
      */
     localMapViewDataRawData () {
       let mapViewData = this.localMapViewData.clone()
-      mapViewData.rawData.features[0] = mapViewData.rawData.features[this.$store.getters.activeRouteIndex]  
+      mapViewData.rawData.features[0] = mapViewData.rawData.features[this.$store.getters.activeRouteIndex]
       return mapViewData.rawData
     }
   },
   watch: {
     /**
      * Every time the response data changes
-     * the map builder is reseted and the
+     * the map builder is reset and the
      * map data is reloaded
      */
     mapViewData: {
       handler: function () {
-        this.refreshMapViewData()      
+        this.refreshMapViewData()
       },
       deep: true
     },
@@ -651,7 +650,7 @@ export default {
       }
     },
     /**
-     * Once the map view is shrinked
+     * Once the map view is shrunk
      * we have to run the setDrawingTool
      * utility again
      */
@@ -688,7 +687,7 @@ export default {
       }
     },
     /**
-     * Whhen the center prop value changes
+     * When the center prop value changes
      * run the centerChanged method that will
      * store the current location on localstorage
      */
@@ -702,7 +701,7 @@ export default {
   methods: {
     /**
      * Refresh map view data after the prop mapViewData has changed
-     * We use a debouncer in order to apply only the last change
+     * We use a debounce in order to apply only the last change
      */
     refreshMapViewData () {
       // When the mapViewData prop changes, we copy its value to a
@@ -712,12 +711,12 @@ export default {
         clearTimeout(this.mapDataViewChangeDebounceTimeoutId)
       }
       this.mapDataViewChangeDebounceTimeoutId = setTimeout(function () {
-        // Create a new instace of MapViewData and set all the props into the local instance
+        // Create a new instance of MapViewData and set all the props into the local instance
         context.localMapViewData = context.mapViewData.clone()
         context.tempPlaces = null
         context.loadMapData()
-        context.refreshAltitudeModal()            
-      }, 500)  
+        context.refreshAltitudeModal()
+      }, 500)
     },
     /**
      * Refresh the altitude modal (force a destroy and a rebuild)
@@ -770,7 +769,7 @@ export default {
     },
     /**
      * Handles the marker clicked event by
-     * peventing the propagation and emitting
+     * preventing the propagation and emitting
      * a local event
      * @param {*} place
      * @param {*} event
@@ -782,9 +781,9 @@ export default {
 
     /**
      * Handle the isochrone polygon clicked event
-     * @param {Number} index 
-     * @param {Object} polygon 
-     * @param {Event} event 
+     * @param {Number} index
+     * @param {Object} polygon
+     * @param {Event} event
      */
     isochroneClicked (index, polygon, event) {
       let isochronePopupContainerRef = this.$refs[`isochronePopupContainer${index}`]
@@ -792,7 +791,7 @@ export default {
       this.$root.appHooks.run('beforeOpenIsochronePopup', {isochronePopupContainerRef, polygon})
     },
     /**
-     * Deals with the map center changed event trigerred by the vue2leaflet
+     * Deals with the map center changed event triggered by the vue2leaflet
      * component. Get the current map center, set it via setMapCenter and
      * define the current myLocationActive based on the last map center
      * @param {*} event
@@ -814,7 +813,7 @@ export default {
       // my location circle should continue to appear as map center
       if (this.myLocationActive) {
         const distance = GeoUtils.calculateDistanceBetweenLocations(this.$store.getters.currentLocation, center, 'm')
-        // For some unknow reason, when a new map center
+        // For some unknown reason, when a new map center
         // is defined it may varies from the location acquired
         // via browser location api. So, we are considering that
         // if this distance is less then 50 meters, then the my
@@ -823,7 +822,7 @@ export default {
       }
     },
     /**
-     * Handle the alternative route index seleted event
+     * Handle the alternative route index selected event
      * @param {*} index
      * @param {*} event
      * @emits activeRouteIndexChanged
@@ -842,8 +841,8 @@ export default {
       const context = this
       this.$store.commit('activeRouteIndex', index)
 
-      // We just want to disalbe the showClickPopups
-      // temporaly, so we get the original state
+      // We just want to disable the showClickPopups
+      // temporarily, so we get the original state
       // set it as false and after a two seconds
       // we restore the original value
       const showPopupBefore = this.showClickPopups
@@ -882,9 +881,9 @@ export default {
         this.storeMapBoundsAndSetMapAsReady()
         this.$emit('zoomChanged', {zoom: event.sourceTarget._zoom, map: this.map, context: this})
       } else {
-        // If the zoom was changed programatically
+        // If the zoom was changed programmatically
         // reset the flag to false, as it has already
-        // been acomplished its goal for one zoom event cycle
+        // been accomplished its goal for one zoom event cycle
         this.featuresJustFitted = false
       }
     },
@@ -912,7 +911,7 @@ export default {
      * Handles the marker move
      * by creating a debounce in order to
      * recalculate the route and update the map
-     * view. A 1 second dealy is applied to avoid
+     * view. A 1 second delay is applied to avoid
      * subsequent marker move updates and get the new
      * position only when the movement has ended
      * @param {*} event
@@ -933,10 +932,10 @@ export default {
      * @param {*} data
      * @emits addRouteStop
      */
-    addStopViaPolylineDrag (data) {      
+    addStopViaPolylineDrag (data) {
       let closestPlaceIndex
       data.latlng = data.event.target.getLatLng()
-      // Get the closest index based on the use stop/route optmization setting
+      // Get the closest index based on the use stop/route optimization setting
       if (this.$store.getters.mapSettings.useStopOptimization) {
         closestPlaceIndex = GeoUtils.getClosestPlaceIndex(data.latlng, this.localMapViewData.places)
       } else {
@@ -1025,7 +1024,7 @@ export default {
 
         if (previousCenter.toString() !== latlng.toString()) {
           this.$emit('mapCenterChanged', latlng)
-        }        
+        }
       } else {
         const routePlaces = this.$store.getters.appRouteData.places
         // TODO: stop using appRouteData, receive places as a prop?
@@ -1104,7 +1103,7 @@ export default {
           if (layer) {
             this.zoomLevel = GeoUtils.zoomLevelByLayer(layer)
           }
-          this.loadAdminArea()         
+          this.loadAdminArea()
         } else {
           this.fitFeaturesBounds()
         }
@@ -1135,7 +1134,7 @@ export default {
         this.dataBounds = GeoUtils.getBounds([], polylineData)
       } else {
         // Add the routes coordinates to the polyline that must
-        // be considered to  the all features databound
+        // be considered to the all features bounds
         for (const rKey in this.localMapViewData.routes) {
           if (this.localMapViewData.routes[rKey].geometry.coordinates) {
             const coords = this.localMapViewData.routes[rKey].geometry.coordinates
@@ -1143,7 +1142,7 @@ export default {
           }
         }
         // Add the polygons coordinates to the polyline that must
-        // be considered to  the all features databound
+        // be considered to  the all features bounds
         for (const pKey in this.localMapViewData.polygons) {
           const polygon = this.localMapViewData.polygons[pKey]
           if (polygon) {
@@ -1151,7 +1150,7 @@ export default {
             polylineData = polylineData.concat(coords)
           }
         }
-        // Build the all features databounds taking into consideration
+        // Build the all features bounds taking into consideration
         // the places and the roues/polygons polyline
         if (this.localMapViewData.hasPlaces() || polylineData.length > 0) {
           this.dataBounds = GeoUtils.getBounds(this.localMapViewData.places, polylineData)
@@ -1237,7 +1236,7 @@ export default {
         // and the user is selecting points to calculate a route, then
         // show this points as markers on the map view. These points will
         // not be synchronized with the app url, so we just add them in the
-        // localMapViewData and we do not emit a mapViewDatachanged event.
+        // localMapViewData and we do not emit a mapViewDataChanged event.
         // This will only happens when two points are selected (then the app
         // goes to the directions mode)
         if (this.mode === constants.modes.place && data.eventName === 'directionsToPoint' || data.eventName === 'directionsFromPoint') {
@@ -1251,9 +1250,9 @@ export default {
     },
 
     /**
-     * Emit the event that will trigger the Set the 
+     * Emit the event that will trigger the Set the
      * directions to place contained in the data object
-     * @param {*} data 
+     * @param {*} data
      * @emits directionsToPoint
      */
     directionsToPoint (data) {
@@ -1261,7 +1260,7 @@ export default {
     },
     /**
      * Emit the event that will trigger the setInputPlace to place contained in the data object
-     * @param {Number} placeIndex 
+     * @param {Number} placeIndex
      * @param {Place} place
      * @emits setInputPlace
      */
@@ -1288,10 +1287,10 @@ export default {
     fitFeaturesBounds (force = false) {
       if (this.fitBounds === true || force) {
         const context = this
-  
+
         // get and use the fit bounds option to determine if the fit should be run
         const maxFitBoundsZoom = this.hasOnlyOneMarker ? context.zoomLevel : this.maxZoom
-  
+
         return new Promise((resolve, reject) => {
           context.buildAndSetBounds()
           // If the map object is already defined
@@ -1323,28 +1322,28 @@ export default {
       this.fitFeaturesBounds(true)
 
       // If the app is in a low resolution mode
-      // hidde the sidebar so that the featues can be seen
+      // hide the sidebar so that the features can be seen
       if (this.$lowResolution) {
         this.eventBus.$emit('setSidebarStatus', false)
       }
     },
 
     /**
-     * Fit the bounds  of the map considering the databounds defined
+     * Fit the bounds of the map considering the data bounds defined
      * @param {Boolean} force
      * @param {Number} maxFitBoundsZoom integer
      */
     fit (maxFitBoundsZoom) {
       if (this.dataBounds) {
         // we set the max zoom in level and then fit the bounds
-        // Temporally disabled the zoomlevel seeting to check impacts (it seems not to be necessary anymore)
+        // Temporally disabled the zoom Level setting to check impacts (it seems not to be necessary anymore)
 
         // To make it work properly we have to wait a bit
         // before fitting the map bounds
         const context = this
         setTimeout(() => {
           // The fit may affect the zoom level.
-          // So we set the programatically zoom flag to let
+          // So we set the programmatically zoom flag to let
           // other methods to have this information if
           // they need, specially method `zoomed`
           context.featuresJustFitted = true
@@ -1369,8 +1368,8 @@ export default {
     },
 
     /**
-     * Handle the map right cick event,
-     * Set the clickLatlng curresnt value
+     * Handle the map right click event,
+     * Set the clickLatlng current value
      * and emits events that will trigger the displaying
      * of the right click floating-context menu
      * @param {Object} event
@@ -1390,15 +1389,15 @@ export default {
     },
 
     /**
-     * Handle the map left cick event
-     * Set the clickLatlng curresnt value
+     * Handle the map left click event
+     * Set the clickLatlng current value
      * and emits events that will trigger the displaying
      * of the place info pop up box
      * @param {Object} event
      * @emits setSidebarStatus (via eventBus)
      * @emits mapLeftClicked (via eventBus)
      */
-    mapLeftClick (event) {       
+    mapLeftClick (event) {
       if (this.$store.getters.pickPlaceIndex !== null) {
         this.pickPlaceViaClick(event)
       } else {
@@ -1410,18 +1409,18 @@ export default {
         } else {
           // If in low resolution and sidebar is open, then left click on the map
           // must close the side bar to allow the user to interact with the map.
-          // If not then the normal left click handlr must be executed
+          // If not then the normal left click handler must be executed
           if (this.$store.getters.leftSideBarOpen && !this.$store.getters.leftSideBarPinned) {
             if (this.$lowResolution) {
               this.eventBus.$emit('setSidebarStatus', false)
             } else {
               this.handleShowLeftClickPlaceInfo(event)
-            }  
+            }
           } else {
             this.handleShowLeftClickPlaceInfo(event)
           }
         }
-      }      
+      }
     },
 
     /**
@@ -1442,7 +1441,7 @@ export default {
 
     /**
      * Handle the left click when the place info box must be shown
-     * @param {*} event 
+     * @param {*} event
      * @emits mapLeftClicked
      */
     handleShowLeftClickPlaceInfo (event) {
@@ -1458,26 +1457,26 @@ export default {
 
     /**
      * Pick place via click when and cal setInputPlace that will emit 'setInputPlace'
-     * @param {*} event 
+     * @param {*} event
      * @uses pickPlaceIndex store getter
      */
-    pickPlaceViaClick (event) {      
+    pickPlaceViaClick (event) {
       let place = new Place(event.latlng.lng, event.latlng.lat)
       let context = this
       let pickPlaceIndex = context.$store.getters.pickPlaceIndex
       let pickPlaceId = context.$store.getters.pickPlaceId
       place.resolve().then(() => {
         context.setInputPlace(pickPlaceIndex, pickPlaceId, place)
-        // Once a place was picked up, 
-        // remove the sstore pick place data
+        // Once a place was picked up,
+        // remove the store pick place data
         context.$store.commit('pickPlaceIndex', null)
         context.$store.commit('pickPlaceId', null)
-      })      
+      })
     },
 
     /**
      * Check if the a lat lng point is inside in one of the map polygons
-     * If it is returnd the polygon points array
+     * If it is returned the polygon points array
      * @param {Latlng} latlng
      * @param {*} lng
      * @returns {Boolean|Array}
@@ -1546,7 +1545,7 @@ export default {
     },
 
     /**
-     * Get position erro according error code
+     * Get position error according error code
      * @param {*} error
      * @returns {String} message
      */
@@ -1586,11 +1585,10 @@ export default {
             resolve(this.map)
           })
         }
-      })      
+      })
     },
     /**
-     * Set the drawing tool. Avoid multiple
-     * calls by udebouncing them
+     * Set the drawing tool. Avoid multiple calls by debouncing
      */
     setDrawingTool () {
       if (!this.$store.getters.embed && appConfig.supportsAvoidPolygonDrawing) {
@@ -1667,13 +1665,13 @@ export default {
 
     /**
      * Set polygon properties
-     * @param {Object} polygon 
+     * @param {Object} polygon
      * @param {Object} polygonData
      */
     setAvoidPolygonPropreties (polygon, polygonData = null) {
      // define polygon feature prop.
      // It will be returned when we get the geojson
-     // rpresentation of the polygon
+     // representation of the polygon
       polygon.feature = polygon.feature || {}
       polygon.feature.type = polygon.feature.type || "Feature";
       polygon.feature.properties = polygon.feature.properties || {};
@@ -1690,7 +1688,7 @@ export default {
     /**
      * Handle polygon created
      * @param {Object} event
-     * @param {Object} map 
+     * @param {Object} map
      */
     avoidPolygonCreated (event, map) {
       var polygon = event.layer
@@ -1700,7 +1698,7 @@ export default {
       polygon.addTo(map)
       polygon.on('click', function () { context.onAvoidPolygonClicked(polygon, map) })
       let expectedPromise = this.$root.appHooks.run('avoidPolygonCreated', {polygon, map, context})
-      
+
       // If a promise is returned
       if (expectedPromise instanceof Promise) {
         expectedPromise.then((result) => {
@@ -1715,7 +1713,7 @@ export default {
     },
     /**
      * Save avoid polygon changes
-     * @param {Object} polygon 
+     * @param {Object} polygon
      * @param {Object} map
      */
     saveAvoidPolygonChanges (polygon, map) {
@@ -1748,7 +1746,7 @@ export default {
         let expectedPromise = this.$root.appHooks.run('avoidPolygonRemoved', {polygon, map, context})
         // If a promise is returned
         if (expectedPromise instanceof Promise) {
-          expectedPromise.then((result) => {            
+          expectedPromise.then((result) => {
             context.notifyAvoidPolygonsChanged()
           }).catch (err => {
             console.log(err)
@@ -1763,7 +1761,7 @@ export default {
 
     /**
      * Enable polygon shape edit and run the corresponding hook
-     * @param {*} polygon 
+     * @param {*} polygon
      */
     enableAvoidPolygonShapeEdit(polygon) {
       polygon.editing.enable()
@@ -1798,7 +1796,7 @@ export default {
         for (const key in this.localAvoidPolygons) {
           const polygonData = context.localAvoidPolygons[key]
           const coordinates = GeoUtils.switchLatLonIndex(polygonData.geometry.coordinates[0])
-  
+
           // Set the color options of the polygons about to be drawn
           let color = context.drawOptions.draw.polygon.shapeOptions.color
           let dashArray = null
@@ -1811,26 +1809,26 @@ export default {
             }
           }
           const polygonOptions = { color: color, dashArray: dashArray}
-            
+
           let polygon
           // Create each polygon using the leaflet tool
           // adn add it to the map object
           let polygonShapeType = GeoUtils.geojsonShapeType(polygonData)
           if (polygonShapeType === 'rectangle') {
-            polygon = Leaflet.rectangle(coordinates, polygonOptions)            
+            polygon = Leaflet.rectangle(coordinates, polygonOptions)
           } else {
             polygon = Leaflet.polygon(coordinates, polygonOptions)
           }
           context.setAvoidPolygonPropreties(polygon, polygonData)
           polygon.addTo(map)
-  
+
           // Add handler for the polygon click event
           polygon.on('click', function (event) {
             context.onAvoidPolygonClicked(polygon, map)
           })
         }
       })
-    },        
+    },
 
     /**
      * Get all the polygons from the map object
@@ -1845,7 +1843,7 @@ export default {
           if (layer instanceof Leaflet.Polygon) {
             let polygonGeoJson = layer.toGeoJSON()
 
-            // properties defined via feature.properties in layer are acessible via 
+            // properties defined via feature.properties in layer are accessible via
             // .properties when the layer is converted to geojson.
             if (polygonGeoJson.properties && polygonGeoJson.properties.avoidPolygon) {
               if (inGeoJsonFormat) {
@@ -1853,14 +1851,14 @@ export default {
               } else {
                 mapAvoidPolygons.push(layer)
               }
-            }            
+            }
           }
         })
       }
       return mapAvoidPolygons
     },
     /**
-     * Enable edit mode for polygon by ading a edit popup when clicked
+     * Enable edit mode for polygon by adding a edit popup when clicked
      * @param {*} polygon
      */
     onAvoidPolygonClicked (polygon, map) {
@@ -1868,11 +1866,11 @@ export default {
       // So the click is used to sav the changes
       if (polygon.editing._enabled) {
        this.saveAvoidPolygonChanges(polygon, map)
-      } else { // build the standard popup, run the popup hoook and open the popup
+      } else { // build the standard popup, run the popup hook and open the popup
         let popupHtmlFragment = this.buildPolygonClickPopupContent(polygon)
         this.$root.appHooks.run('beforeShowAvoidPolygonPopup', {popupHtmlFragment, polygon})
         polygon.bindPopup(popupHtmlFragment).openPopup()
-      }      
+      }
     },
 
     /**
@@ -1912,7 +1910,7 @@ export default {
       }
     },
     /**
-     * Highligh a rounte point on the active route index
+     * Highlight a route point on the active route index
      * @param {*} routePointIndex
      */
     hightlightRoutePoint (routePointIndex) {
@@ -1935,12 +1933,12 @@ export default {
       this.highlightedRoutePointIndex = null
     },
     /**
-     * Dosable pick a place mode by
-     * settting the pick pace index as null
+     * Disable pick a place mode by
+     * setting the pick pace index as null
      * @param event
      */
     disablePickPlaceMode (event) {
-      if (event.which === 27) { // esc 
+      if (event.which === 27) { // esc
         this.$store.commit('pickPlaceIndex', null)
       }
     },
@@ -1971,7 +1969,7 @@ export default {
        */
       this.eventBus.$on('clearMap', () => {
         context.mapDataBuilder = null
-        // When the clearMap event is triggred, we reset places and routes
+        // When the clearMap event is triggered, we reset places and routes
         context.localMapViewData.places = []
         context.localMapViewData.routes = []
         context.localMapViewData.polygons = []
@@ -1982,7 +1980,7 @@ export default {
       /**
        * When a place focus is changed (a new place is selected among the
        * ones listed on the map) updates the map center if the distance
-       * between the old center and the new is greatet then 50 emter
+       * between the old center and the new is greater then 50 meters
        */
       this.eventBus.$on('placeFocusChanged', (place) => {
         context.focusedPlace = place
@@ -2008,7 +2006,7 @@ export default {
 
       this.eventBus.$on('mapSettingsChanged', function () {
         context.setProviders()
-      })      
+      })
 
       this.eventBus.$on('highlightPolylineSections', (extraInfo) => {
         context.extraInfo = extraInfo
@@ -2021,9 +2019,9 @@ export default {
     /**
      * Toggle the accessible mode by
      * storing the flag under the mapSettings store
-     * to do so we get the current setgin object, update it,
+     * to do so we get the current setting object, update it,
      * convert it to a stringified representation and
-     * save it to the browsers'local storage
+     * save it to the browsers local storage
      * @uses localStorage
      */
     toggleAcessibleMode () {

--- a/src/fragments/places-carousel/places-carousel.js
+++ b/src/fragments/places-carousel/places-carousel.js
@@ -108,7 +108,7 @@ export default {
       }
     },
     /**
-     * REtrieves the place layer
+     * Retrieves the place layer
      * @param {*} place
      */
     placeLayer (place) {
@@ -146,13 +146,13 @@ export default {
       this.$emit('placeSelected', index)
     },
     /**
-     * Hanles the click outside event
+     * Handles the click outside event
      * emitting the closed event
      * @emits close
      */
     clickOutside (event) {
       const source = event.currentTarget.activeElement
-      // If the accessibility buttom is hit
+      // If the accessibility button is hit
       // we don't have to emit the closed
       if (!source.classList.contains('do-not-trigger-close-bottom-nav')) {
         this.$emit('close')
@@ -181,7 +181,7 @@ export default {
       }
     },
     /**
-     * Emmit the directions to latlg
+     * Emmit the directions to latlng
      * @param {*} place
      */
     directionsTo (place) {
@@ -189,7 +189,7 @@ export default {
       this.$emit('closed')
     },
     /**
-     * Emmit the directions to latlg
+     * Emmit the directions to latlng
      * @param {*} place
      */
     gotToPlace (place) {

--- a/src/models/app-route-data.js
+++ b/src/models/app-route-data.js
@@ -4,7 +4,7 @@ import utils from '@/support/utils'
  */
 class AppRouteData {
   /**
-   * Contructor
+   * Constructor
    * @param {*} places
    * @param {*} options
    */
@@ -28,5 +28,5 @@ class AppRouteData {
     return clone
   }
 }
-// export the AppRouteDatar class
+// export the AppRouteData class
 export default AppRouteData

--- a/src/models/place.js
+++ b/src/models/place.js
@@ -25,12 +25,12 @@ class Place {
     this.coordinates = null
 
     // place properties
-    this.properties = options.properties || {} // objct properties, including layer
+    this.properties = options.properties || {} // object properties, including layer
 
     // If the place was valid before be cleared
     this.wasValidBeforeCleared = options.wasValidBeforeCleared !== undefined ? options.wasValidBeforeCleared : false
 
-    // The indx of the input associated to the Place object
+    // The index of the input associated to the Place object
     this.inputIndex = options.inputIndex
 
     // The id of the place returned by the API

--- a/src/pages/maps/maps.js
+++ b/src/pages/maps/maps.js
@@ -65,7 +65,7 @@ export default {
     },
     /**
      * Determines if the simple search component is visible
-     * based on the embed mode value, the mapready and the sidebar visibility
+     * based on the embed mode value, the mapReady state and the sidebar visibility state
      * @returns {Boolean} isVisible
      */
     simpleSearchIsVisible () {
@@ -106,7 +106,7 @@ export default {
       return height
     },
     /**
-     * Returns the zoom level tha must be used based on 
+     * Returns the zoom level tha must be used based on
      * the app route options and the default zoom level
      * @returns {Number} zoom
      */
@@ -144,7 +144,7 @@ export default {
      * must be fitted based on differ of the last mapViewDta timestamp
      * and if it is the firs load
      * @returns {Boolean} fit
-     * 
+     *
      */
     fitMapBounds () {
       if (this.mapViewData.timestamp && this.previousMapViewDataTimeStamp !== this.mapViewData.timestamp && this.$store.getters.mapSettings.alwaysFitBounds) {
@@ -181,10 +181,10 @@ export default {
     }
   },
   beforeRouteUpdate (to, from, next) {
-    // Altough the mode is defined in the beforeEnter route event
+    // Although the mode is defined in the beforeEnter route event
     // when te browser back button is pressed and we are changing from
     // similar types of route - like directions with two places and
-    // directins with one (for round trip), then the beforeEnter is not trigered
+    // directions with one (for round trip), then the beforeEnter is not triggered
     if (to.fullPath.startsWith(resolver.directions())) {
       RouteUtils.setDirectionsModeBasedOnRoute(to)
     }
@@ -207,12 +207,12 @@ export default {
       }
     },
     /**
-     * Stores the new zomm value and set the
+     * Stores the new zoom value and set the
      * searchBtnAvailable flag as true, since
      * once the map has been moved, the user may wants to
      * refresh the search to get features within the
      * visible map view
-     * @param {Object} { zoom: Object, map: Object, context: Object} 
+     * @param {Object} { zoom: Object, map: Object, context: Object}
      */
     zoomChanged (data) {
       this.$root.appHooks.run('zoomChanged', data)
@@ -240,9 +240,9 @@ export default {
       this.eventBus.$emit('refreshSearch')
     },
     /**
-     * Defines if the searchBtnAvailable based on 
+     * Defines if the searchBtnAvailable based on
      * how much the map has been moved
-     * @param {Object} data 
+     * @param {Object} data
      */
     mapCenterMoved (data) {
       // Only enables the refresh search btn
@@ -253,7 +253,7 @@ export default {
     },
     /**
      * Save the new map center in mapSettings when it changes
-     * and emit a mapcenterchanged event via eventBus
+     * and emit a mapCenterChanged event via eventBus
      * @param {*} latlng
      * @emits mapCenterChanged [via eventBus]
      */
@@ -264,10 +264,10 @@ export default {
       this.$store.dispatch('saveSettings', mapSettings).then(() => {
         context.$root.appHooks.run('mapCenterChanged', mapSettings.mapCenter)
         context.eventBus.$emit('mapCenterChanged', mapSettings.mapCenter)
-      })      
+      })
     },
     /**
-     * Set the view height using the iner height
+     * Set the view height using the inner height
      */
     setViewHeight () {
       this.viewHeight = window.innerHeight
@@ -275,7 +275,7 @@ export default {
     /**
      * Refresh the view size using a debounce
      * it respond to touch event, so we just want
-     * to aply the new size when the event ends
+     * to apply the new size when the event ends
      */
     refreshViewSizeAfterTouchMode () {
       clearTimeout(this.touchmoveDebounceTimeoutId)
@@ -288,7 +288,7 @@ export default {
     },
     /**
      * Deal with the marker click event
-     * by opennning the bottom nav, setting the active place
+     * by opening the bottom nav, setting the active place
      * and running the setViewHeight
      * @param {*} place
      */
@@ -323,7 +323,7 @@ export default {
       this.setViewHeight()
     },
     /**
-     * Handle place index selected and emitts event via evetBus
+     * Handle place index selected and emits event via eventBus
      * @param {*} index
      * @emits placeFocusChanged [via eventBus]
      */
@@ -350,7 +350,7 @@ export default {
       // The mapViewData is watched by the map
       // component and the content re-rendered
       // when it changes. So, by changing it here
-      // the map component is refresed
+      // the map component is refreshed
       this.mapViewData = mapViewData
 
       // once the mapViewData is changed, the
@@ -410,7 +410,7 @@ export default {
      * in a local property. so in case
      * there are more then one map (future)
      * we can check which map must be accessed
-     * @param {*} mapViewGuid 
+     * @param {*} mapViewGuid
      */
     orsMapCreated (mapViewGuid) {
       this.mapViewGuid = mapViewGuid
@@ -418,7 +418,7 @@ export default {
     /**
      * When a marker has been dragged
      * emits the markerDragged event (via eventbus)
-     * @param {Object} marker 
+     * @param {Object} marker
      * @emits markerDragged via eventbus
      */
     markerDragged (marker) {
@@ -426,11 +426,11 @@ export default {
     },
 
     /**
-     * When a directions from point is hit, 
+     * When a directions from point is hit,
      * emit a directionsFromPoint event via eventbus.
      * The map-view component does not emit events via
      * eventBus, only local events to its container (this component)
-     * @param {Object} data 
+     * @param {Object} data
      * @emits directionsFromPoint via eventbus
      */
     directionsFromPoint (data) {
@@ -439,10 +439,10 @@ export default {
     /**
      * Trigger directions based on the data passed
      * that includes a Place by clearing the map
-     * and by emitting the directionsToPoint evet (via eventBus)
+     * and by emitting the directionsToPoint event (via eventBus)
      * The map-view component does not emit events via
      * eventBus, only local events to its container (this component)
-     * @param {Objet} data {place: Place}
+     * @param {Object} data {place: Place}
      */
     directionsToPoint (data) {
       let context = this
@@ -455,9 +455,9 @@ export default {
     },
 
     /**
-     * Check if the data contaisn the pick place index
+     * Check if the data contains the pick place index
      * and emits the setInputPlace via eventBus
-     * @param {*} data 
+     * @param {*} data
      * @emits setInputPlace
      */
     setInputPlace (data) {
@@ -467,7 +467,7 @@ export default {
     },
     /**
      * Navigate the app to the single place mode
-     * @param {Place} place 
+     * @param {Place} place
      */
     gotToPlace (place) {
       this.$store.commit('mode', constants.modes.place)
@@ -481,11 +481,11 @@ export default {
       this.bottomNavActive = false
     },
      /**
-     * When an `add isochrones center` option is hit, 
+     * When an `add isochrones center` option is hit,
      * emits an addAsIsochroneCenter event via eventbus.
      * The map-view component does not emit events via
      * eventBus, only local events to its container (this component)
-     * @param {Object} data 
+     * @param {Object} data
      * @emits addAsIsochroneCenter via eventbus
      */
     addAsIsochroneCenter (data) {
@@ -493,22 +493,22 @@ export default {
     },
 
     /**
-     * When an `add route stop` option is hit, 
+     * When an `add route stop` option is hit,
      * emits an addRouteStop event via eventbus.
      * The map-view component does not emit events via
      * eventBus, only local events to its container (this component)
-     * @param {Object} data 
+     * @param {Object} data
      * @emits addRouteStop via eventbus
      */
     addRouteStop (data) {
       this.eventBus.$emit('addRouteStop', data)
     },
     /**
-     * When an `add destination to route` option is hit, 
+     * When an `add destination to route` option is hit,
      * emits an addDestinationToRoute event via eventbus.
      * The map-view component does not emit events via
      * eventBus, only local events to its container (this component)
-     * @param {Object} data 
+     * @param {Object} data
      * @emits addDestinationToRoute via eventbus
      */
     addDestinationToRoute (data) {
@@ -541,10 +541,10 @@ export default {
       }
     },
     /**
-     * When an avoid polygons option changes, 
+     * When an avoid polygons option changes,
      * merge the avoid polygons array into a multipolygon and
      * emits an avoidPolygonsChanged event via eventbus.
-     * @param {Array} polygons 
+     * @param {Array} polygons
      * @emits avoidPolygonsChanged via eventbus
      */
     avoidPolygonsChanged (polygons) {
@@ -597,21 +597,21 @@ export default {
 
     // Set sidebar initial state (open/closed)
     let sidebarStartOpen = false
-    if (appConfig.sidebarStartsOpenInHeighResolution && this.$highResolution) {
+    if (appConfig.sidebarStartsOpenInHighResolution && this.$highResolution) {
       sidebarStartOpen = true
     }
     this.$store.commit('setLeftSideBarIsOpen', sidebarStartOpen)
 
     const context = this
     // Listen to the mapViewDataChanged event and call the
-    // necessary methods when it happes
+    // necessary methods when it happens
     this.eventBus.$on('mapViewDataChanged', function (mapViewData) {
       context.$root.appHooks.run('mapViewDataChanged', mapViewData)
       context.setMapDataAndUpdateMapView(mapViewData)
       context.setViewHeightAndBottomNav()
     })
 
-    // Set the modal open falgs to true when
+    // Set the modal open flags to true when
     // a show-<something> events happen
     this.eventBus.$on('showAltitudeModal', () => {
       context.isAltitudeModalOpen = true
@@ -625,15 +625,15 @@ export default {
     this.eventBus.$on('loadAvoidPolygons', (avoidPolygons) => {
       context.localAvoidPolygons = avoidPolygons
     })
-  
-    // When the touch move event occours
+
+    // When the touch move event occurs
     // the view size may change (mobile devices)
     // due to the url bar visibility
     document.addEventListener('touchmove', () => {
       this.refreshViewSizeAfterTouchMode()
     })
 
-    // Run the init methods whe 
+    // Run the init methods whe
     // this component is created
     this.loadRoute()
     this.setModalState()

--- a/src/pages/maps/maps.route.js
+++ b/src/pages/maps/maps.route.js
@@ -14,7 +14,7 @@ const embedParameters = '/:embed?/:locale?'
 // Build the optional placesNames Path
 var optionalplaceNamesPath = ''
 for (let index = 2; index <= 15; index++) {
-  optionalplaceNamesPath += `/:placeName${index}?`  
+  optionalplaceNamesPath += `/:placeName${index}?`
 }
 
 const mapRoutes = [
@@ -28,7 +28,7 @@ const mapRoutes = [
       // As this was causing a weird redirection we had to tell vue router to
       // go the target route in this case
       const currentPath = location.hash.replace('#', '')
-      // Only laod the root route if the cleanMap flag is true
+      // Only load the root route if the cleanMap flag is true
       if (currentPath !== '' && currentPath !== '/' && currentPath !== rootPath && !store.getters.cleanMap) {
         // In case of loading root route, set the
         // default mode as place mode
@@ -51,8 +51,9 @@ const mapRoutes = [
     }
   },
   {
-    // The maximum number of places/points of a route is 15. so, we can have 15 places more the data parameter that contains the coordinates for all the palces in que query encoded in base64 format
-    // The minimum is one (becaue of round trip needs only one place)
+    // The maximum number of places/points of a route is 15. so, we can have 15 places more the data parameter that
+    // contains the coordinates for all the places in que query encoded in base64 format
+    // The minimum is one (because of round trip needs only one place)
     path: `${directionsPath}:placeName1${optionalplaceNamesPath}/data/:data${embedParameters}`,
     name: 'MapDirections',
     component: Maps,

--- a/src/plugins/plugin-example/plugin-example.js
+++ b/src/plugins/plugin-example/plugin-example.js
@@ -1,10 +1,10 @@
 /**
- * This is an example of a simple plugin aiming at demonstrating how you can add 
+ * This is an example of a simple plugin aiming at demonstrating how you can add
  * custom behavior to the maps client. To make the plugin work it is necessary
- * to import this class in the hooks.js, instantiate it and run the plugin methods 
- * on hooks defined on hooks.js 
+ * to import this class in the hooks.js, instantiate it and run the plugin methods
+ * on hooks defined on hooks.js
  * @see /src/config/hook-example.js
- * 
+ *
  * It is possible to use values from the store, like, for example:
  * store.getters.mapCenter, store.getters.mapBounds and store.getters.mode
  * It is also possible to emit events using the eventBus. For example:
@@ -13,16 +13,16 @@
 class PluginExample {
   /**
    * PluginExample constructor.
-   * IMPORTANT: this constructor is expected 
+   * IMPORTANT: this constructor is expected
    * to be called on the hooks.js the `appLoaded` hook
    */
   constructor (vueInstance) {
-    this.vueInstance = vueInstance     
+    this.vueInstance = vueInstance
   }
 
   /**
    * Is called when the app is loaded and the map view is ready
-   * 
+   *
    * IMPORTANT: this method is expected to be called on
    * hooks.js on the mapReady hook or automatically via catchAll
    * @param {Object} hookData
@@ -34,15 +34,15 @@ class PluginExample {
   }
 
   /**
-   * Method to get the current mapViewData and pottentily
-   * change it. As it is an object, when you change it you are 
-   * changin the origial object.
-   * The MapView is watching to changes to this object and 
+   * Method to get the current mapViewData and potentially
+   * change it. As it is an object, when you change it you are
+   * changing the original object.
+   * The MapView is watching to changes to this object and
    * will re-render the displayed content on the map view
    * when it is changed.
    * IMPORTANT: this method is expected to be called on
    * hooks.js on the mapViewDataChanged hook.
-   * @param {*} mapViewData 
+   * @param {*} mapViewData
    */
   mapViewDataChanged (mapViewData) {
     // change the mapViewData object

--- a/src/plugins/readme.md
+++ b/src/plugins/readme.md
@@ -1,14 +1,22 @@
 # Plug-ins folder #
 
-This folder is reserved for plug-ins. Each plug-in must be contained in a folder created under the `plugins` folder. For example: src/plugin/my-awesome-plugin. No file should be directly put in the root of the `plugins` folder.
+Each plug-in must be contained in a folder created under the `plugins` folder.
+For example: src/plugin/my-awesome-plugin. No file should be directly put in the root of the `plugins` folder.
 
-Each plug-in is expected to have a class and methods/functions that can be called on hooks defined in the hooks.js. Check the ExamplePlugin in `plugin-example/plugin-example.js` and `/src/config/hook-example.js` for more details.
+Each plug-in must have a class and methods/functions that can be called on hooks defined in the hooks.js.
+Check the ExamplePlugin in `plugin-example/plugin-example.js` and `/src/config/hook-example.js` for more details.
 
 ## What can be used in a plug-in ? ##
 
-Besides the parameters passed to each method via hook call, inside a plug-in you can use the values stored in the [vuex](https://vuex.vuejs.org/guide/) store (you need to import import store from '@/store/store') and access, for example, `store.getters.mapBounds`. You can also use the app constants to compare values. In order to do this import `constants` from `@/resources/constants`
+Next to the parameters passed to each method via hook call, inside a plug-in you can use the values stored in the
+[vuex](https://vuex.vuejs.org/guide/) store (you need to import store from '@/store/store') and access,
+for example `store.getters.mapBounds`.
+You can also use the app constants to compare values.
+For this import `constants` from `@/resources/constants`.
 
-Within the plug-in you can also set listeners to events emitted via `evenBus`, for example `mapViewDataChanged`, as well as emit those events. Some of the events emitted via `eventBus` are:
+Within the plug-in you can also set listeners to events emitted via `evenBus`, for example `mapViewDataChanged`,
+as well as emit those events.
+Some events emitted via `eventBus` are:
 
 - `mapViewDataChanged`
 - `loadAvoidPolygons`

--- a/src/resources/lists/grades.js
+++ b/src/resources/lists/grades.js
@@ -1,4 +1,4 @@
-// List of route sgrades
+// List of route grades
 
 const grades = [
   'grade1',

--- a/src/resources/lists/route-smoothness.js
+++ b/src/resources/lists/route-smoothness.js
@@ -1,4 +1,4 @@
-// List of route smothness
+// List of route smoothness
 const routeSmothness = [
   'impassable',
   'very_horrible',

--- a/src/store/modules/app-state.js
+++ b/src/store/modules/app-state.js
@@ -76,9 +76,9 @@ const actions = {
         if (defaultSettings[key] !== undefined && savingSettings[key] != undefined) {
           let saveVal = JSON.stringify(savingSettings[key])
           let defaultVal = JSON.stringify(defaultSettings[key])
-          // locale is an exception, becasue the app auto detects the browser locale
+          // locale is an exception, because the app auto detects the browser locale
           // so the user would not be able to save the default language as preferred
-          if (saveVal === defaultVal && key !== 'locale') { 
+          if (saveVal === defaultVal && key !== 'locale') {
             delete savingSettings[key]
           }
         }

--- a/src/support/admin-area-loader.js
+++ b/src/support/admin-area-loader.js
@@ -9,7 +9,7 @@ import theme from '@/config/theme'
 class AdminAreaLoader {
   /**
    * Build the admin area query filter based on place properties
-   * @param {*} place 
+   * @param {*} place
    * @returns {Object} adminAreaFilter
    */
   buildAdminAreaFilter(place, layer) {
@@ -41,7 +41,7 @@ class AdminAreaLoader {
 
   /**
    * Get the admin area polygon for a given place
-   * @param {Place} place 
+   * @param {Place} place
    * @return {Promise}
    */
   getAdminAreaPolygon(place) {
@@ -49,20 +49,20 @@ class AdminAreaLoader {
       if (!place.placeName) {
         resolve([])
       }
-      // maek a copy of the original layer 
+      // make a copy of the original layer
       // before updating the place via resolver
       let layer = place.properties.layer
       let layersThatSupportAdminPolygon = ['county', 'locality', 'region', 'country']
-      
+
       if (layersThatSupportAdminPolygon.includes(layer)) {
         // Define the zoom level used to resolve
         let layerZoom = GeoUtils.zoomLevelByLayer(layer)
-  
+
         let context = this
         place.resolve(layerZoom).then(() => {
           let adminAreaFilter = context.buildAdminAreaFilter(place, layer)
           NominatimService.query(adminAreaFilter).then((response) => {
-            let validPolygons = context.adjustAdminArea(place, response.data)            
+            let validPolygons = context.adjustAdminArea(place, response.data)
             if (validPolygons) {
               resolve(validPolygons)
             } else {
@@ -80,8 +80,8 @@ class AdminAreaLoader {
 
   /**
    * check if a Place is inside of any of the polygons passed
-   * @param {*} polygons 
-   * @param {Place} place 
+   * @param {*} polygons
+   * @param {Place} place
    */
   isPointInsidePolygons (polygons, place) {
     let isInside = false
@@ -89,9 +89,9 @@ class AdminAreaLoader {
     for (let key in polygons) {
       // Adjust the order of lat lng
       let polygonCoords = GeoUtils.switchLatLonIndex(polygons[key].geometry.coordinates)
-  
-      // Include the pois that are inside the area polygon
-      if (PolygonUtils.isInsidePolygon(place, polygonCoords)) {              
+
+      // Include the POIs that are inside the area polygon
+      if (PolygonUtils.isInsidePolygon(place, polygonCoords)) {
         isInside = true
         break
       }
@@ -100,9 +100,9 @@ class AdminAreaLoader {
   }
 
   /**
-   * Adjust the area plygon and validate it
-   * @param {*} place 
-   * @param {*} polygon 
+   * Adjust the area polygon and validate it
+   * @param {*} place
+   * @param {*} polygon
    * @returns {Object| false}
    */
   adjustAdminArea(place, data) {
@@ -111,7 +111,7 @@ class AdminAreaLoader {
       let area = data[key]
       if (area.geojson.type !== 'Point') {
         let hasCoordinatesAsMultyPolygon = Array.isArray(area.geojson.coordinates[0]) && Array.isArray(area.geojson.coordinates[0][0])
-        
+
         // Treat as multipolygon in both cases
         if (area.geojson.type === 'MultiPolygon' || hasCoordinatesAsMultyPolygon ) {
           let splitPolygons = PolygonUtils.splitMultiPolygonIntoPolygons(area.geojson)
@@ -139,8 +139,8 @@ class AdminAreaLoader {
   }
   /**
    * Validate a polygon
-   * @param {*} polygon 
-   * @param {*} place 
+   * @param {*} polygon
+   * @param {*} place
    * @returns {Object|false} polygon
    */
 

--- a/src/support/app-modes/app-mode.js
+++ b/src/support/app-modes/app-mode.js
@@ -19,7 +19,7 @@ import isochronesMode from './strategies/isochrones-mode'
  */
 class AppMode {
   /**
-   * Contructor
+   * Constructor
    * @param {String} modeTo - constants.modes
    */
   constructor (modeTo) {

--- a/src/support/app-modes/strategies/directions-mode.js
+++ b/src/support/app-modes/strategies/directions-mode.js
@@ -60,14 +60,14 @@ class DirectionsMode {
 
     // In the directions mode, the options parameter may contains an options object
     // that is expected to be used as the ORS API request options (avoid_polygons, avoid_features etc)
-    // So, as they are stringfied on the url, we try to parse them back to an object
+    // So, as they are stringified on the url, we try to parse them back to an object
     if (appRouteData.options && appRouteData.options.options) {
       appRouteData.options.options = Utils.tryParseJson(appRouteData.options.options) || appRouteData.options.options
     }
 
     appRouteData.places = RouteUtils.getRoutePlaces(currentRoute)
 
-    // If there are direct waipoints (at least 2)
+    // If there are direct waypoints (at least 2)
     // add their indexes to the options
     if (appRouteData.options.directPlaces) {
       appRouteData.options.directPlaces.forEach(index => {

--- a/src/support/app-modes/strategies/isochrones-mode.js
+++ b/src/support/app-modes/strategies/isochrones-mode.js
@@ -49,7 +49,7 @@ class IsochronesMode {
 
     // In the directions mode, the options parameter may contains an options object
     // that is expected to be used as the ORS API request options (avoid_polygons, avoid_features etc)
-    // So, as they are stringfied on the url, we try to parse them back to an object
+    // So, as they are stringified on the url, we try to parse them back to an object
     if (appRouteData.options && appRouteData.options.options) {
       appRouteData.options.options = Utils.tryParseJson(appRouteData.options.options) || appRouteData.options.options
     }

--- a/src/support/app-modes/strategies/place-mode.js
+++ b/src/support/app-modes/strategies/place-mode.js
@@ -22,7 +22,7 @@ class PlaceMode {
       appRouteData.options.layer = appRouteData.places[0].properties.layer || appRouteData.options.layer
       appRouteData.options.country = appRouteData.places[0].properties.country || appRouteData.options.country
 
-      // Update the zoom acording the place type/layer
+      // Update the zoom according to the place type/layer
       appRouteData.options.zoom = GeoUtils.zoomLevelByLayer(appRouteData.options.layer)
     }
     return appRouteData

--- a/src/support/app-modes/strategies/roundtrip-mode.js
+++ b/src/support/app-modes/strategies/roundtrip-mode.js
@@ -51,7 +51,7 @@ class RoundTripMode {
 
     // In the directions mode, the options parameter may contains an options object
     // that is expected to be used as the ORS API request options (avoid_polygons, avoid_features etc)
-    // So, as they are stringfied on the url, we try to parse them to convert them back to an object
+    // So, as they are stringified on the url, we try to parse them to convert them back to an object
     if (appRouteData.options.options) {
       appRouteData.options.options = Utils.tryParseJson(appRouteData.options.options) || appRouteData.options.options
     }

--- a/src/support/geo-utils.js
+++ b/src/support/geo-utils.js
@@ -5,7 +5,7 @@ import moment from 'moment'
 import Vue from 'vue'
 import HtmlMarker from '@/fragments/html-marker/HtmlMarker'
 
-// The import below will add some methods to Leaflet.GeometryUtil 
+// The import below will add some methods to Leaflet.GeometryUtil
 // Even if it is not been accessed within this class, it is being used!
 import 'leaflet-geometryutil'
 
@@ -67,7 +67,7 @@ const geoUtils = {
    * Build the markers based in an array of coordinates
    * @param {Array} places - coordinates of the marker
    * @param {Boolean} isRoute - default true
-   * @param {Place|null} highlightedPlace - place to have a corresponding marker hightlighed (red)
+   * @param {Place|null} highlightedPlace - place to have a corresponding marker highlighted (red)
    * @returns {Array} of markers
    */
   buildMarkers: (places, isRoute = false, highlightedPlace = null) => {
@@ -80,7 +80,7 @@ const geoUtils = {
         // Define the marker color
         const lastIndexKey = places.length - 1
         let coloredMarkerName = geoUtils.getMarkerColor(key, lastIndexKey, isRoute)
-  
+
         if (highlightedPlace) {
           if (place.equals(highlightedPlace)) {
             coloredMarkerName = 'red'
@@ -90,20 +90,20 @@ const geoUtils = {
         }
 
         let buildAsRoute = isRoute && places.length > 1
-  
+
         // Build the marker
         const markerIcon = geoUtils.buildMarkerIcon(coloredMarkerName, place.index, buildAsRoute)
         const marker = { position: { lng: place.lng, lat: place.lat}, icon: markerIcon}
-  
+
         // If the way point array has the third parameter, it is its label
         marker.label = place.placeName || `${place.lng},${place.lat}`
         if (!isNaN(place.index) && isRoute) {
           marker.label = `(${place.index}) ${marker.label}`
         }
-  
+
         // If the way point array has the fourth parameter, it is its way point json data
         marker.place = place
-  
+
         // Add the markers to the returning array
         markers.push(marker)
 
@@ -114,7 +114,7 @@ const geoUtils = {
 
   /**
    * Determines if a geojson is a rectangle
-   * @param {Object} geojson 
+   * @param {Object} geojson
    * @returns {Boolean}
    */
   geojsonIsARectangle(geojson) {
@@ -140,9 +140,9 @@ const geoUtils = {
   },
 
   /**
-   * Determines the type of polygon a geojson has. 
-   * If the geojson is of the type  Polygon it retirns false.
-   * @param {Object} geojson 
+   * Determines the type of polygon a geojson has.
+   * If the geojson is of the type  Polygon it returns false.
+   * @param {Object} geojson
    * @returns {String|false}
    */
   geojsonShapeType(geojson) {
@@ -171,7 +171,7 @@ const geoUtils = {
 
   /**
    * Calculate geodesic area
-   * @param {Array} latlngs 
+   * @param {Array} latlngs
    */
   geodesicArea(latlngs) {
     return Leaflet.GeometryUtil.geodesicArea(latlngs)
@@ -179,8 +179,8 @@ const geoUtils = {
 
   /**
    * Get readable area
-   * @param {Number} area 
-   * @param {String} unit 
+   * @param {Number} area
+   * @param {String} unit
    */
   readableArea(latlngs, unit) {
     let area = Leaflet.GeometryUtil.geodesicArea(latlngs)
@@ -217,7 +217,7 @@ const geoUtils = {
   },
 
   /**
-   * Build a bounding box the also includes the plaes and the polyline
+   * Build a bounding box the also includes the places and the polyline
    * @param {Array} places
    * @param {Array} polyline containing arrays where index 0 is lng and index 1 is lat
    * @returns {Array} of 2 objects {lon:..., lat:...}
@@ -408,9 +408,9 @@ const geoUtils = {
   },
 
   /**
-   * Getthe index of a place on the polyline arrray
-   * @param {Place} place 
-   * @param {Array} polylineArr 
+   * Get the index of a place on the polyline array
+   * @param {Place} place
+   * @param {Array} polylineArr
    * @returns  {Integer|null} indexOnPolyline
    */
   getPlaceIndexOnPolylineArray (place, polylineArr) {
@@ -424,7 +424,7 @@ const geoUtils = {
         lng: polylineCoords[1]
       }
 
-      // Check the place that has the shortest distace to the polyline point
+      // Check the place that has the shortest distance to the polyline point
       let currentDistance = geoUtils.calculateDistanceBetweenLocations(polylineCoordsLatlng, place, 'm')
       if (currentDistance === 0) {
         // Get the closest polyline point index
@@ -442,9 +442,9 @@ const geoUtils = {
   },
   /**
    * Get the inject index considering the source polyline point
-   * @param {Array} places 
-   * @param {Array} polylineArr 
-   * @param {Integer} sourceIndex 
+   * @param {Array} places
+   * @param {Array} polylineArr
+   * @param {Integer} sourceIndex
    * @returns {Integer} injectIndex
    */
   getStopIndexFromSourcePoint(places, polylineArr, sourceIndex) {
@@ -474,7 +474,7 @@ const geoUtils = {
   },
 
   /**
-   * Return the zoom level accoding the layer
+   * Return the zoom level according to the layer
    */
   zoomLevelByLayer: (layer) => {
     const map = layerZoomMapping
@@ -518,8 +518,8 @@ const geoUtils = {
 
   /**
    * Select a feature from a feature list by a give zoom
-   * the feature with the zomm level (according the layer type)
-   * being closest to the givn zoom level will be selected
+   * the feature with the zoom level (according the layer type)
+   * being closest to the given zoom level will be selected
    * @param {*} zoom
    * @param {*} places
    * @returns {Place} place
@@ -532,9 +532,9 @@ const geoUtils = {
         const featureZoom = geoUtils.zoomLevelByLayer(places[key].properties.layer)
         const selectedFeatureZoom = geoUtils.zoomLevelByLayer(selectedPlace.properties.layer)
 
-        // If the difference betwen the reference zoom and
+        // If the difference between the reference zoom and
         // the current feature zoom is smaller than the
-        // the difference betwen the previously selected feature
+        // the difference between the previously selected feature
         // then replace the current selected feature bt the current feature
         if (featureZoom % zoom < selectedFeatureZoom % zoom) {
           selectedPlace = places[key]
@@ -550,8 +550,8 @@ const geoUtils = {
    * @param {LatLng} p0 Point the polyline point
    * @param {LatLng} p1 Point The reference line is defined by the polyline LatLng to p1.
    * @param {LatLng} p2 The point in question.
-   * @returns {Number} 
-   *  >0 for p2 left of the line through this point and p1, 
+   * @returns {Number}
+   *  >0 for p2 left of the line through this point and p1,
    *  =0 for p2 on the line,
    *  <0 for p2 right of the line through this point an p1.
    * @see {@link http://geomalgorithms.com/a03-_inclusion.html Inclusion of a Point in a Polygon} by Dan Sunday.

--- a/src/support/map-data-services/map-view-data-builder.js
+++ b/src/support/map-data-services/map-view-data-builder.js
@@ -34,8 +34,8 @@ class MapViewDataBuilder {
 
   /**
    * Get the response type, considering the endpoint and the response formart
-   * It is used to determin the map data extractor that is gonna be used
-   * to extract the data from the rsponse and render it
+   * It is used to determine the map data extractor that is gonna be used
+   * to extract the data from the response and render it
    */
   getSourceType = () => {
     let sourceType

--- a/src/support/map-data-services/ors-filter-util.js
+++ b/src/support/map-data-services/ors-filter-util.js
@@ -47,7 +47,7 @@ const getFilterValue = (filter, service) => {
   // Proceed only if filter is available considering other filter's value
   if (filterAvailable && FilterDependencyService.isAvailable(filterClone)) {
     // Get the filter with value updated considering dependencies and filter rules
-    if (filterClone.type === constants.filterTypes.wrapper && filterClone.props) {      
+    if (filterClone.type === constants.filterTypes.wrapper && filterClone.props) {
       filterValue = getChildrenFilterValue(filterClone, service)
       filterValue = filterClone.valueAsObject ? filterValue : JSON.stringify(filterValue)
       // Apply filter conditions like min, multiplier etc
@@ -92,7 +92,7 @@ const adjustdFilterValue = (filter, filterValue) => {
 }
 
 /**
- * Get a filter by acestry and item index
+ * Get a filter by ancestry and item index
  * @param {*} ancestry
  * @param {*} itemIndex
  * @returns {Object} accessor
@@ -106,13 +106,13 @@ const getFilterByAncestryAndItemIndex = (ancestry, itemIndex = null) => {
 
 /**
  * Build the ancestry accessor string as a goal to build a string
- * that represents the path to retrive a target item present in
+ * that represents the path to retrieve a target item present in
  * @see /resources/ors-map-filter.js.
  * The map filters is a array of objects that may contains
- * child objects under the `props` prperty, that, if defined,
+ * child objects under the `props` property, that, if defined,
  * also contains an array of child objects. Many levels of objects
  * with props and child objets is possible. This method creates
- * a string that represets the navigation required to access a target
+ * a string that represents the navigation required to access a target
  * object considering the index of each step
  * @param {*} ancestry
  * @param {*} itemIndex
@@ -120,7 +120,7 @@ const getFilterByAncestryAndItemIndex = (ancestry, itemIndex = null) => {
  */
 const buildAncestryAcessorString = (ancestry, itemIndex = null) => {
   let path
-  // Multiple levels of ancestry is suppported.
+  // Multiple levels of ancestry is supported.
   // So, if ancestry is an array, then the first value
   // is the parent level of ancestry and we have to
   // resolve it recursively
@@ -129,7 +129,7 @@ const buildAncestryAcessorString = (ancestry, itemIndex = null) => {
       let subPath = buildAncestryAcessorString(ancestry[0])
       // In case of recursive ancestry, the value in
       // position 1 is the immediate parent and we must
-      // assembly this with the subpath generated
+      // assembly this with the sub-path generated
       path = `[${ancestry[1]}].props${subPath}`
     } else {
       // In case there is not recursive ancestry
@@ -151,7 +151,7 @@ const buildAncestryAcessorString = (ancestry, itemIndex = null) => {
 }
 
 /**
- * Apply filtervalue conditions
+ * Apply filter value conditions
  * @param {*} filterClone
  * @param {*} filterValue
  * @returns {*} filterValue
@@ -172,7 +172,7 @@ const applyFilterValueConditions = (filterClone, filterValue) => {
 }
 
 /**
- * Get filter children value stringfied
+ * Get filter children value stringified
  * @param {*} filter
  * @param {*} service
  * @returns {String}
@@ -194,7 +194,7 @@ const getChildrenFilterValue = (filter, service) => {
 }
 
 /**
- * Set filter value by specifiing filter name
+ * Set filter value by specified filter name
  * @param {*} filterName
  * @param {*} filterValue
  * @param {*} OrsMapFiltersAccessor

--- a/src/support/map-data-services/ors-params-parser.js
+++ b/src/support/map-data-services/ors-params-parser.js
@@ -10,9 +10,9 @@ import main from '@/main'
 
 const orsParamsParser = {
   /**
-   * Build the args object to be used in atocomplete places request
+   * Build the args object to be used in autocomplete places request
    * @param {*} placeName
-   * @param {Boolean} restrictToBbox - restricct the search to stored bbox
+   * @param {Boolean} restrictToBbox - restrict the search to stored bbox
    * @returns {Object} args
    */
   buildPlaceSearchArgs: (placeName, restrictToBbox = false) => {
@@ -22,14 +22,14 @@ const orsParamsParser = {
       size: 8,
       focus_point: [store.getters.mapCenter.lat, store.getters.mapCenter.lng]
     }
-    // If is set to restrict the search to currrent mapBounds,
+    // If is set to restrict the search to current mapBounds,
     // then apply the restriction
     if (restrictToBbox) {
       let bbox = orsParamsParser.getCurrentBbox()
       // If the bounding box is valid, then add it to the args
       if (bbox) {
         args.boundary_bbox = bbox
-        delete args.focus_point // if we restrict by bounday bbox focus point is not necessary
+        delete args.focus_point // if we restrict by boundary bbox focus point is not necessary
       }
     }
 
@@ -73,20 +73,20 @@ const orsParamsParser = {
         [mapBounds.rect.min_lat, mapBounds.rect.min_lon],
         [mapBounds.rect.max_lat, mapBounds.rect.max_lon]
       ]
-      return bbox  
+      return bbox
     } else {
       return false
-    }    
+    }
   },
 
   /**
    * Build the args object to be used in search POIs request
    * @param {Object} filters {
-   *  category_group_ids: Array, 
-   *  category_ids: Array, 
-   *  name: Array [String], 
-   *  wheelchair: Array ["yes","no","limited","designated"], 
-   *  smoking: Array ['dedicated','yes','no','separated','isolated','outside'], 
+   *  category_group_ids: Array,
+   *  category_ids: Array,
+   *  name: Array [String],
+   *  wheelchair: Array ["yes","no","limited","designated"],
+   *  smoking: Array ['dedicated','yes','no','separated','isolated','outside'],
    *  fee: Array ['yes', 'no']
    * } @see https://openrouteservice.org/dev/#/api-docs/pois/post
    * @param {Number} limit
@@ -180,7 +180,7 @@ const orsParamsParser = {
 
     // Define the extra info that must be be requested
     // based on the map settings
-    const extraInfo = orsParamsParser.buildExtraInfoOptions(mapSettings)    
+    const extraInfo = orsParamsParser.buildExtraInfoOptions(mapSettings)
 
     // Set args object
     const args = {
@@ -242,7 +242,7 @@ const orsParamsParser = {
 
   /**
    * Define the extra info that must be be requested
-   * @param {Object} mapSettings 
+   * @param {Object} mapSettings
    * @returns {Array} extraInfo
    */
   buildExtraInfoOptions (mapSettings) {
@@ -257,18 +257,18 @@ const orsParamsParser = {
         if (key === constants.extraInfos.roadaccessrestrictions) {
           if (profileObj.supportsRoadaccessrestrictions) {
             extraInfo.push(constants.extraInfos[key])
-          } 
+          }
         } else if (key === constants.extraInfos.traildifficulty) {
           if (profileObj.supportsTraildifficulty) {
             extraInfo.push(constants.extraInfos[key])
-          } 
+          }
         } else if (key === constants.extraInfos.tollways) {
           if (profileObj.supportsTollways) {
             extraInfo.push(constants.extraInfos[key])
-          } 
+          }
         } else {
           extraInfo.push(constants.extraInfos[key])
-        }     
+        }
       }
     }
     return extraInfo
@@ -298,7 +298,7 @@ const orsParamsParser = {
 
   /**
    * Add OrsMapFilters to intoArgs object to a given service
-   * @param {Object} intoArgs - taget object to the filters that will be extracted from sourceFilters
+   * @param {Object} intoArgs - target object to the filters that will be extracted from sourceFilters
    * @param {Object} orsFilters
    * @param {String} service
    * @returns {Array} intoArgs
@@ -313,7 +313,7 @@ const orsParamsParser = {
       // Check if the filter matches the conditions to be used
       if (available && !filter.onlyInFront && (!filter.useInServices || filter.useInServices.includes(service))) {
 
-        // Update filter value and children's value based on their depedencies
+        // Update filter value and children's value based on their dependencies
         if (filter.props) {
           DependencyService.updateFieldsStatus(filter.props)
         }
@@ -324,7 +324,7 @@ const orsParamsParser = {
         if (orsParamsParser.isFilterValueValid(filter, filterValue)) {
           orsParamsParser.setFilterVal(filter, filterValue, intoArgs)
         } else if (intoArgs[filter.name] && !orsParamsParser.isFilterValueValid(intoArgs[filter.name])) {
-          // If the filter is available and has not a valud value, remove it
+          // If the filter is available and has not a valid value, remove it
           if (FilterDependencyService.isAvailable(filter)) {
             delete intoArgs[filter.name]
           }
@@ -336,16 +336,16 @@ const orsParamsParser = {
 
   /**
    * Set the filter value into an args object
-   * @param {*} filter 
-   * @param {*} filterValue 
-   * @param {*} intoArgs 
+   * @param {*} filter
+   * @param {*} filterValue
+   * @param {*} intoArgs
    * @hook mapFilterAdded
    */
   setFilterVal (filter, filterValue, intoArgs) {
     // If the parent is a wrapping object and it is already defined in intoArgs, add it to the object
     if (filter.type === constants.filterTypes.wrapper && typeof intoArgs[filter.name] !== 'undefined') {
       intoArgs[filter.name] = orsParamsParser.getMergedParameterValues(intoArgs[filter.name], filterValue)
-    } else { // if not 
+    } else { // if not
       if (filter.valueAsObject && typeof filterValue === 'string') {
         const parsed = Utils.tryParseJson(filterValue)
         intoArgs[filter.name] = parsed || filterValue
@@ -379,7 +379,7 @@ const orsParamsParser = {
   getMergedParameterValues (current, adding) {
     const addingParsedJson = typeof adding === 'string' ? Utils.tryParseJson(adding) : adding
 
-    // If what we wanna add was an object stringfied
+    // If what we wanna add was an object stringified
     // that was successfully parsed, continue this way
     if (addingParsedJson) {
       let newObj = null

--- a/src/support/map-data-services/ors-response-data-extractors/route-data.js
+++ b/src/support/map-data-services/ors-response-data-extractors/route-data.js
@@ -12,7 +12,7 @@ const routeData = {
       const polylinesHighlighted = []
 
       // Build the sections
-      // Each section contains a label, a color and 
+      // Each section contains a label, a color and
       // may contain multiple polylines
       for (const key in extraInfo.sections) {
         const section = extraInfo.sections[key]
@@ -21,12 +21,12 @@ const routeData = {
           color: section.color,
           polylines: [] // It starts empty and will be populated below
         }
-        // Use the intervals data to extract the 
+        // Use the intervals data to extract the
         // polyline data for the given interval
         for (const intervalKey in section.intervals) {
           const interval = section.intervals[intervalKey]
           // since we are getting items from an array
-          // starting with the index 0, the amout of
+          // starting with the index 0, the amount of
           // items is the final position + 1
           const amoundOfItems = interval[1] +1
           const segment = polyLineData.slice(interval[0], amoundOfItems)
@@ -39,7 +39,7 @@ const routeData = {
       return polylinesHighlighted
     }
   },
-  
+
   /**
    * Get the response data source type based on the endpoint and the type of responseData
    * @param {String} endpoint
@@ -47,7 +47,7 @@ const routeData = {
    * @returns {String}  response source type
    */
   getSourceType (endpoint, responseData) {
-    // In the case of directions andpoint, there are
+    // In the case of directions and pois, there are
     // two possibilities. If the response is an object (json) or a gpx (xml)
     if (endpoint === '/directions') {
       if (typeof responseData === 'object') {

--- a/src/support/map-data-services/ors-response-util.js
+++ b/src/support/map-data-services/ors-response-util.js
@@ -41,7 +41,7 @@ const isANewResponse = (newResponse, oldResponse) => {
 }
 
 /**
- * Determines if the new mapviewdata is really different from the old one
+ * Determines if the new map-view-data is really different from the old one
  * using the response timestamp metadata as reference
  * @param {*} newResponse
  * @param {*} oldResponse

--- a/src/support/polygon-utils.js
+++ b/src/support/polygon-utils.js
@@ -42,7 +42,7 @@ const PolygonUtils = {
 
   /**
    * Merge polygons into one multipolygon
-   * @param {Array} polygons 
+   * @param {Array} polygons
    * @returns {Object}
    */
   mergePolygonsIntoMultiPolygon(polygons) {
@@ -57,7 +57,7 @@ const PolygonUtils = {
   },
   /**
    * Merge polygons into one multipolygon
-   * @param {Object} multiPolygon 
+   * @param {Object} multiPolygon
    * @returns {Array} polygons
    */
   splitMultiPolygonIntoPolygons(multiPolygon) {
@@ -76,7 +76,7 @@ const PolygonUtils = {
 
   /**
    * Flat polygon coordinates
-   * @param {*} coordinates 
+   * @param {*} coordinates
    */
   flatCoordinates (coordinates) {
     let flatten = []
@@ -94,8 +94,8 @@ const PolygonUtils = {
    * Checks if a single point is contained in a polyline or polygon
    * Note that L.Polygon, L.GeodesicPolygons, and L.GeodesicCircles are types of L.Polygon.
    * @param {Leaflet.LatLng} point A geographical point
-   * @param {Array} of Latlng points
-   * @returns {boolean} True if the point is contained in the polygon or polyline; otherwise, 
+   * @param {Array} polygonCoords: array of LatLng points
+   * @returns {boolean} True if the point is contained in the polygon or polyline; otherwise,
    *
    */
   isInsidePolygon: (point, polygonCoords) => {
@@ -115,8 +115,8 @@ const PolygonUtils = {
 
   /**
    * Determines if a point is inside the polygon bounds
-   * @param {Leaflet.latlng} point 
-   * @param {Leaflet.Polygon} polygon 
+   * @param {Leaflet.latlng} point
+   * @param {Leaflet.Polygon} polygon
    * @returns {Boolean} insideBounds
    */
   isInsidePolygonBounds (point, polygon) {
@@ -127,12 +127,12 @@ const PolygonUtils = {
 
   /**
    * Test for a point in a polygon or on the bounding lines of the polygon.  The
-   * coordinates (L.LatLngs) for a GeodesicPolygon are set to follow the earth's
+   * coordinates (L.LatLng) for a GeodesicPolygon are set to follow the earth's
    * curvature when the GeodesicPolygon object is created.  Since L.Polygon
    * extends Leaflet.Polyline we can use the same method for both.  Although, for
    * L.Polyline, we only get points on the line even if a collection of lines
    * appear to make a polygon.
-   * 
+   *
    * This is a JavaScript and Leaflet port of the `wn_PnPoly()` C++ function by Dan Sunday.
    * Unlike the C++ version, this implementation does include points on the line and vertices.
    *
@@ -140,7 +140,7 @@ const PolygonUtils = {
    * @returns {Number} The winding number (=0 only when the point is outside)
    *
    * @see {@link http://geomalgorithms.com/a03-_inclusion.html Inclusion of a Point in a Polygon} by Dan Sunday.
-   * @see {@link https://github.com/Fragger/Leaflet.Geodesic Leaflet.Geodesc} for information about Leaflet.Geodesc by Fragger.
+   * @see {@link https://github.com/Fragger/Leaflet.Geodesic Leaflet.Geodesic} for information about Leaflet.Geodesic by Fragger.
    * @see {@link https://en.wikipedia.org/wiki/Winding_number} to understand winding number
    */
   getWindingNumber: (point, vertices) => {

--- a/src/support/route-utils.js
+++ b/src/support/route-utils.js
@@ -65,7 +65,7 @@ const RouteUtils = {
         poiPlaces.push(index)
       }
     })
-    // If there are direct waipoints
+    // If there are direct waypoints
     // add their indexes to the options
     if (directPlaces.length > 0) {
       appRouteData.options.directPlaces = directPlaces


### PR DESCRIPTION
Changes to cleanup most spelling and grammar errors in markdown files, docstrings, comments.
No code was touched.
Changelog entries were adjusted to adhere to the template.