### PR TITLE
fix(route information popup): make text in route info not split mid-word

### DIFF
--- a/cypress/e2e/directions.cy.js
+++ b/cypress/e2e/directions.cy.js
@@ -64,6 +64,21 @@ describe('Directions component', () => {
       cy.get('.custom-html-icon-div').eq(0).should('have.css', 'background-color', 'rgb(0, 128, 0)')
       cy.get('.custom-html-icon-div').eq(1).should('have.css', 'background-color', 'rgb(255, 0, 0)')
     })
+
+    it('shows the popup correctly', () => {
+      let contentWidth = 0
+      cy.get('.cy-route-popup-icon').then((element) => {
+        contentWidth += element.width()
+      })
+      cy.get('.cy-route-popup-text').then((element) => {
+        contentWidth += element.width()
+      })
+
+      // content width is larger than width of above 2 divs combined
+      cy.get('.leaflet-popup-content').then(($popup) => {
+        expect($popup.width()).to.be.gte(contentWidth)
+      })
+    })
   })
 
   context('loads round trip from url link', () => {

--- a/src/fragments/map-view/components/ors-l-polyline/ors-l-polyline.js
+++ b/src/fragments/map-view/components/ors-l-polyline/ors-l-polyline.js
@@ -1,5 +1,5 @@
 import OrsExtendedPolyline from './ors-extended-polyline'
-import { LPolyline, LTooltip, LPopup} from 'vue2-leaflet'
+import {LPolyline, LPopup, LTooltip} from 'vue2-leaflet'
 import constants from '@/resources/constants'
 import GeoUtils from '@/support/geo-utils'
 import Utils from '@/support/utils'
@@ -202,16 +202,13 @@ export default {
           iconStyle = 'transform: scaleY(-1) rotate(45deg)'
         }
         if (tooltipIcon) {
-          let tooltip = `
-          <div>
-            <div style='min-width:30px;width:20%;height:50px;float:left'>
-              <span style='${iconStyle}' class="material-icons">${tooltipIcon}</span>
-            </div>
-            <div style='min-width:180px'>${tooltipInnerContent}</div>
+          return `
+          <div style="display:flex;align-items:center;">
+            <div class="material-icons cy-route-popup-icon" style='min-width:40px;${iconStyle};'>${tooltipIcon}</div>
+            <div class="cy-route-popup-text" style='min-width:max-content;'>${tooltipInnerContent}</div>
           </div>`
-          return tooltip
         } else {
-          return `<div><div style='min-width:180px'>${tooltipInnerContent}</div></div>`
+          return `<div><div style='min-width:max-content;' class="route-popup-text">${tooltipInnerContent}</div></div>`
         }
       }
     },

--- a/src/fragments/map-view/components/ors-l-polyline/ors-l-polyline.js
+++ b/src/fragments/map-view/components/ors-l-polyline/ors-l-polyline.js
@@ -196,15 +196,13 @@ export default {
           tooltipInnerContent += `<br> ${this.$t('global.duration')}: ${humanizedData.duration}`
         }
         let tooltipIcon = this.tooltipIcon
-        let iconStyle = ''
         if (store.getters.mapSettings.skipAllSegments) {
-          tooltipIcon = 'near_me'
-          iconStyle = 'transform: scaleY(-1) rotate(45deg)'
+          tooltipIcon = 'arrow_forward'
         }
         if (tooltipIcon) {
           return `
           <div style="display:flex;align-items:center;">
-            <div class="material-icons cy-route-popup-icon" style='min-width:40px;${iconStyle};'>${tooltipIcon}</div>
+            <div class="material-icons cy-route-popup-icon" style='min-width:40px;'>${tooltipIcon}</div>
             <div class="cy-route-popup-text" style='min-width:max-content;'>${tooltipInnerContent}</div>
           </div>`
         } else {

--- a/src/fragments/map-view/map-view-leaflet.css
+++ b/src/fragments/map-view/map-view-leaflet.css
@@ -39,12 +39,8 @@
 }
 
 .map-view >>> .leaflet-popup-content {
-  max-width: 400px;
   word-break: break-all;
   min-width: 150px;
-  max-height: 400px;
-  overflow-x: hidden;
-  overflow-y: auto;
 }
 
 .map-view.low-resolution >>> .leaflet-popup-content {


### PR DESCRIPTION
Previously divs and floating features were used for the layout of the popups of route information. Though this provided suitable display normally, the size of the leaflet popup is based on the size of the div. When the icon for the profile is floated, this moves the text but doesn't change the size of the underlying div, which meant that the text got wrapped into new lines. In this commit, the divs have been replaced with spans using inline-block display so that the parent div resizes as expected.

fix #277