### PR TITLE
fix: floating menu using event bus

### DIFF
--- a/src/fragments/sidebar/components/top-menu/components/floating-menu/FloatingMenu.vue
+++ b/src/fragments/sidebar/components/top-menu/components/floating-menu/FloatingMenu.vue
@@ -7,7 +7,7 @@
     <v-list>
       <template v-for="(item, index) in menuItems">
         <v-layout row :key="index" v-if="item.show">
-          <v-btn class="floating-item" :key="index" flat v-if="item.emitEvent" @click="eventBus.$emit(item.emitEvent)">
+          <v-btn class="floating-item" :key="index" flat v-if="item.emitEvent" @click="emitEvent(item.emitEvent)">
             <v-icon :title="item.title" left color="dark">{{item.icon}}</v-icon>
             <template>{{item.title}}</template>
           </v-btn>

--- a/src/fragments/sidebar/components/top-menu/components/floating-menu/floating-menu.js
+++ b/src/fragments/sidebar/components/top-menu/components/floating-menu/floating-menu.js
@@ -1,4 +1,6 @@
 import constants from '@/resources/constants'
+import {EventBus} from '@/common/event-bus'
+
 export default {
   props: {
     openOnHover: {
@@ -86,6 +88,9 @@ export default {
           context.setReadyStatus()
         }
       }, 100)
+    },
+    emitEvent (event) {
+      EventBus.$emit(event)
     }
   },
   created() {


### PR DESCRIPTION
the floating menu was still using the eventBus attached to the Vue instance, which was moved to a separate module recently. See https://github.com/GIScience/ors-map-client/pull/326

- add method to call the EventBus for usage in the Vue file