### PR TITLE
fix: git and ssl versions in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node:16-alpine as build-stage
 WORKDIR /opt/client/
 
 # System deps and app setup:
-RUN apk --no-cache add build-base=0.5-r3 git=2.38.3-r1 \
+RUN apk --no-cache add build-base=0.5-r3 git=2.38.4-r0 \
     && npm install -g pnpm@7.26.2
 
 # Add diretories with necessary config files
@@ -23,7 +23,7 @@ RUN pnpm build
 # 2. Stage: Start server with needed files only
 FROM nginx:stable-alpine as production-stage
 
-RUN apk add --no-cache openssl=1.1.1s-r0 bash=5.1.16-r2 && \
+RUN apk add --no-cache openssl=1.1.1t-r0 bash=5.1.16-r2 && \
     rm -rf /usr/share/nginx/html/* \
 
 USER nginx


### PR DESCRIPTION
the previously specified versions of these packages can not be installed anymore.

If this keeps happening we should switch to more general versions installation instead