### PR TITLE
feat: load plugin images properly

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -67,7 +67,15 @@ module.exports = {
         }
       },{
         test: /\.(woff|woff2|eot|ttf|otf|png|svg|jpg|jpeg|gif|ico)$/i,
-        type: 'asset'
+        type: 'asset',
+        exclude: resolveRoot('src/plugins')
+      },{
+        test: /\.(woff|woff2|eot|ttf|otf|png|svg|jpg|jpeg|gif|ico)$/i,
+        type: 'asset',
+        include: resolveRoot('src/plugins'),
+        generator: {
+          filename: 'static/img/[name][ext]'
+        }
       },{
         test: /\.(geojson|kml|gpx|txt)$/i,
         type: 'asset/source',


### PR DESCRIPTION
to not output images from plugins to the root directory but to the `static/img` folder, the rule for loading assets was adjusted to exclude the plugins folder.
A separate rule was created to the be used for the plugin folder only.