### PR TITLE
fix: avoid_countries not working

### DIFF
--- a/src/fragments/forms/fields-container/components/form-fields/form-fields.js
+++ b/src/fragments/forms/fields-container/components/form-fields/form-fields.js
@@ -171,6 +171,7 @@ export default {
             }
             // If the item object has texts for the current locale, get it and then set it as the item text
             item.itemText = item[this.$store.getters.mapSettings.locale] || item[defaultMapSettings.locale] || item.itemValue
+            item.itemValue = item[parameter.itemValue]
           } else { // item is not an object, but a simple value
             let itemObj = {
               itemValue: item,


### PR DESCRIPTION
this was due to the itemValue not being set from the parameter definition. Accidentally broken in 222423eca3ec4904256699ad50f66b9dedf5aeca

Fixed by reintroducing the missing line