### PR TITLE
fix(tiles): Fix the usage of the legacy osm tile service to the new one.

### DIFF
--- a/src/App.cy.js
+++ b/src/App.cy.js
@@ -14,7 +14,7 @@ describe('<App />', () => {
   beforeEach(() => {
     cy.spy(EventBus, '$on').as('eventBusRegisterSpy')
     cy.spy(EventBus, '$emit').as('eventBusEmitSpy')
-    cy.intercept('GET', 'https://*.tile.openstreetmap.org/*/*/*.png', {fixture: 'map-pin.jpg'})
+    cy.intercept('GET', 'https://tile.openstreetmap.org/*/*/*.png', {fixture: 'map-pin.jpg'})
     new AppLoader().fetchApiInitialData()
     cy.stub(Footer.computed, 'appVersion', () => {
       // appVersion reads from process.env, which isn't available in browser during testing

--- a/src/config-examples/app-config-example.js
+++ b/src/config-examples/app-config-example.js
@@ -63,7 +63,7 @@ const appConfig = {
       id: 'osm',
       visible: false,
       attribution: '&copy; <a target="_blank" href="https://osm.org/copyright">OpenStreetMap</a> contributors',
-      url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
       maxZoom: 19
     },
     {

--- a/src/fragments/map-view/MapView.cy.js
+++ b/src/fragments/map-view/MapView.cy.js
@@ -7,7 +7,7 @@ import store from '@/store/store'
 
 describe('Map rendering', () => {
   beforeEach(() => {
-    cy.intercept('GET', 'https://*.tile.openstreetmap.org/*/*/*.png', {fixture: 'map-pin.jpg'})
+    cy.intercept('GET', 'https://tile.openstreetmap.org/*/*/*.png', {fixture: 'map-pin.jpg'})
   })
   it('should render map-view with single place', () => {
     new AppLoader().fetchApiInitialData()


### PR DESCRIPTION
The old tile server `https://*.tile.openstreetmap.org/*/*/*.png` is changed to https://tile.openstreetmap.org/*/*/*.png as described here https://github.com/openstreetmap/operations/issues/737. The new service has enhanced load balancing and performance, the old service will be less and less maintained.