### PR TITLE
fix: altitude not showing asc & desc summary

### DIFF
--- a/src/fragments/charts/altitude/altitude.js
+++ b/src/fragments/charts/altitude/altitude.js
@@ -37,7 +37,6 @@ export default {
   },
   data: () => ({
     parsedData: null,
-    localMapViewData: null,
     chartOptions: {
       aspectRatio: 4,
       scales: {
@@ -64,8 +63,8 @@ export default {
       return data
     },
     summary () {
-      if (this.localMapViewData) {
-        const summary = this.localMapViewData.routes[this.$store.getters.activeRouteIndex].summary
+      if (this.mapViewData) {
+        const summary = this.mapViewData.routes[this.$store.getters.activeRouteIndex].summary
         return summary
       }
     },


### PR DESCRIPTION
after 7f28bddd `localMapViewData` was not used anymore in the build() function. This broke the summary as it was always `null`.
Moved to direct `mapViewData` instead and removed unused `localMapViewData`